### PR TITLE
Centraliza as requisições à API de Eventos em um serviço

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -16,11 +16,7 @@ class Event
   end
 
   def self.all
-    conn = Faraday.new do |faraday|
-      faraday.response :raise_error
-    end
-    response = conn.get("https://localhost:3000/events")
-    events = JSON.parse(response.body, symbolize_names: true)
+    events = EventsApiService.get_events
     events.select { |event| DateTime.now.before?(event[:start_date].to_date) }.map { |event| build_event(event) }
   rescue Faraday::Error => error
     Rails.logger.error(error)
@@ -28,13 +24,8 @@ class Event
   end
 
   def self.request_event_by_id(event_id)
-    conn = Faraday.new do |faraday|
-      faraday.response :raise_error
-    end
-    response = conn.get("http://localhost:3000/events/#{event_id}")
-
-    data = JSON.parse(response.body, symbolize_names: true)
-    build_event(data)
+    event_params = EventsApiService.get_event_by_id event_id
+    build_event(event_params)
   rescue Faraday::Error => error
     Rails.logger.error(error)
     nil

--- a/app/services/events_api_service.rb
+++ b/app/services/events_api_service.rb
@@ -1,0 +1,18 @@
+class EventsApiService
+  def self.get_events
+    self.request('http://localhost:3000/events', :get)
+  end
+
+  def self.get_event_by_id event_id
+    self.request("http://localhost:3000/events/#{event_id}", :get)
+  end
+
+  def self.request url, method
+    conn = Faraday.new do |faraday|
+      faraday.response :raise_error
+    end
+    JSON.parse(conn.send(method, url).body, symbolize_names: true)
+  rescue Faraday::Error => e
+    raise e
+  end
+end

--- a/app/services/events_api_service.rb
+++ b/app/services/events_api_service.rb
@@ -1,10 +1,11 @@
 class EventsApiService
+  BASE_URL = 'http://localhost:3000/events'
   def self.get_events
-    self.request('http://localhost:3000/events', :get)
+    self.request(BASE_URL, :get)
   end
 
   def self.get_event_by_id event_id
-    self.request("http://localhost:3000/events/#{event_id}", :get)
+    self.request("#{BASE_URL}/#{event_id}", :get)
   end
 
   def self.request url, method

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Event, type: :model do
     it 'Deveria receber toda a lista de eventos disponíveis' do
       travel_to(Time.zone.local(2024, 01, 01, 00, 04, 44))
       json = File.read(Rails.root.join('spec/support/json/events_list.json'))
-      url = 'https://localhost:3000/events'
+      url = 'http://localhost:3000/events'
       response = double('faraday_response', body: json, status: 200)
       allow_any_instance_of(Faraday::Connection).to receive(:get).with(url).and_return(response)
       allow(response).to receive(:success?).and_return(true)
@@ -137,7 +137,7 @@ RSpec.describe Event, type: :model do
     end
 
     it 'e deveria receber array vazio em caso de erro na requisição' do
-      url = 'https://localhost:3000/events'
+      url = 'http://localhost:3000/events'
       response = double('faraday_response', body: "{}", status: 500)
       allow(Faraday).to receive(:get).with(url).and_return(response)
       allow(response).to receive(:success?).and_return(false)
@@ -149,7 +149,7 @@ RSpec.describe Event, type: :model do
     it 'só recebe eventos que não aconteceram' do
       travel_to(Time.zone.local(2024, 01, 01, 00, 04, 44))
       json = File.read(Rails.root.join('spec/support/json/error_events_list.json'))
-      url = 'https://localhost:3000/events'
+      url = 'http://localhost:3000/events'
       response = double('faraday_response', body: json, status: 200)
       allow_any_instance_of(Faraday::Connection).to receive(:get).with(url).and_return(response)
       allow(response).to receive(:success?).and_return(true)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -39,15 +39,15 @@ RSpec.configure do |config|
     driven_by :rack_test
   end
 
-  config.before(:each, type: :system) do
-    driven_by(:cuprite, screen_size: [ 1440, 810 ], options: {
-      js_errors: false,
-      headless: true,
-      process_timeout: 25,
-      timeout: 20,
-      browser_options: { "no-sandbox" => nil }
-    })
-  end
+  # config.before(:each, type: :system) do
+  #   driven_by(:cuprite, screen_size: [ 1440, 810 ], options: {
+  #     js_errors: false,
+  #     headless: true,
+  #     process_timeout: 25,
+  #     timeout: 20,
+  #     browser_options: { "no-sandbox" => nil }
+  #   })
+  # end
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false

--- a/spec/services/events_api_service_spec.rb
+++ b/spec/services/events_api_service_spec.rb
@@ -1,0 +1,92 @@
+require 'rails_helper'
+
+describe EventsApiService, type: :model do
+  describe 'Usuário faz uma requisição para uma lista de eventos' do 
+    it 'e recebe uma lista de eventos com sucesso' do
+      events = [{
+            event_id: 1,
+            name: 'Aprendedo a cozinhar',
+            url_event: 'https://ecvitoria.com.br/public/Inicio/',
+            local_event: 'Rua dos morcegos, 137, CEP: 40000000, Salvador, Bahia, Brasil',
+            limit_participants: 30,
+            banner: 'https://via.placeholder.com/300x200',
+            logo: 'https://via.placeholder.com/100x100',
+            description: 'Aprenda a fritar um ovo',
+            event_owner: 'Samuel',
+            event_agendas: [],
+            start_date: '2024-01-01',
+            end_date: '2024-02-01'
+        },
+        {
+          event_id: 2,
+          name: 'Aprendendo a Nadar',
+          url_event: 'https://ecvitoria.com.br/public/Inicio/',
+          local_event: 'Rua dos Elefantes, 138, CEP: 50000000, Salvador, Bahia, Brasil',
+          limit_participants: 40,
+          banner: 'https://via.placeholder.com/300x200',
+          logo: 'https://via.placeholder.com/100x100',
+          description: 'Aprenda a nadar rápido',
+          event_owner: 'Cesar',
+          event_agendas: [],
+          start_date: '2024-02-01',
+          end_date: '2024-03-01'
+        }
+      ]
+  
+  
+      response = double('response', status: 200, body: events.to_json)
+      allow_any_instance_of(Faraday::Connection).to receive(:get).with('http://localhost:3000/events').and_return(response)
+      results = EventsApiService.get_events
+  
+      expect(results[0][:name]).to eq 'Aprendedo a cozinhar'
+  
+  
+    end
+  
+    it 'e ocorre erro na requisição' do
+      allow_any_instance_of(Faraday::Connection).to receive(:get).with('http://localhost:3000/events').and_raise(Faraday::Error)
+      expect { EventsApiService.get_events }.to raise_error(Faraday::Error)
+    end
+  end
+
+  describe 'Usuário faz uma requisição para um evento' do
+    it 'e recebe um evento com sucesso' do
+      event = {
+        event_id: 1,
+        name: 'Aprendedo a cozinhar',
+        url_event: 'https://ecvitoria.com.br/public/Inicio/',
+        local_event: 'Rua dos morcegos, 137, CEP: 40000000, Salvador, Bahia, Brasil',
+        limit_participants: 30,
+        banner: 'https://via.placeholder.com/300x200',
+        logo: 'https://via.placeholder.com/100x100',
+        description: 'Aprenda a fritar um ovo',
+        event_owner: 'Samuel',
+        event_agendas: [],
+        start_date: '2024-01-01',
+        end_date: '2024-02-01'
+      }
+
+      response = double('response', status: 200, body: event.to_json)
+      allow_any_instance_of(Faraday::Connection).to receive(:get).with('http://localhost:3000/events/1').and_return(response)
+      result = EventsApiService.get_event_by_id(event[:event_id])
+
+      expect(result[:name]).to eq 'Aprendedo a cozinhar'
+      expect(result[:url_event]).to eq 'https://ecvitoria.com.br/public/Inicio/'
+      expect(result[:local_event]).to eq 'Rua dos morcegos, 137, CEP: 40000000, Salvador, Bahia, Brasil'
+      expect(result[:limit_participants]).to eq 30
+      expect(result[:banner]).to eq 'https://via.placeholder.com/300x200'
+      expect(result[:logo]).to eq 'https://via.placeholder.com/100x100'
+      expect(result[:description]).to eq 'Aprenda a fritar um ovo'
+      expect(result[:event_owner]).to eq 'Samuel'
+      expect(result[:event_agendas]).to eq []
+    end
+
+  end
+
+  it 'e ocorre erro na requisição' do
+    allow_any_instance_of(Faraday::Connection).to receive(:get).with('http://localhost:3000/events/1').and_raise(Faraday::Error)
+    expect { EventsApiService.get_event_by_id(1) }.to raise_error(Faraday::Error)
+  end
+
+  
+end

--- a/spec/services/events_api_service_spec.rb
+++ b/spec/services/events_api_service_spec.rb
@@ -20,7 +20,7 @@ describe EventsApiService, type: :model do
         {
           event_id: 2,
           name: 'Aprendendo a Nadar',
-          url_event: 'https://ecvitoria.com.br/public/Inicio/',
+          url_event: 'https://ecbahia.com.br/public/Inicio/',
           local_event: 'Rua dos Elefantes, 138, CEP: 50000000, Salvador, Bahia, Brasil',
           limit_participants: 40,
           banner: 'https://via.placeholder.com/300x200',
@@ -36,9 +36,29 @@ describe EventsApiService, type: :model do
   
       response = double('response', status: 200, body: events.to_json)
       allow_any_instance_of(Faraday::Connection).to receive(:get).with('http://localhost:3000/events').and_return(response)
-      results = EventsApiService.get_events
+      result = EventsApiService.get_events
   
+      
+
       expect(results[0][:name]).to eq 'Aprendedo a cozinhar'
+      expect(results[0][:url_event]).to eq 'https://ecvitoria.com.br/public/Inicio/'
+      expect(results[0][:local_event]).to eq 'Rua dos morcegos, 137, CEP: 40000000, Salvador, Bahia, Brasil'
+      expect(results[0][:limit_participants]).to eq 30
+      expect(results[0][:banner]).to eq 'https://via.placeholder.com/300x200'
+      expect(results[0][:logo]).to eq 'https://via.placeholder.com/100x100'
+      expect(results[0][:description]).to eq 'Aprenda a fritar um ovo'
+      expect(results[0][:event_owner]).to eq 'Samuel'
+      expect(results[0][:event_agendas]).to eq []
+
+      expect(results[1][:name]).to eq 'Aprendendo a Nadar'
+      expect(results[1][:url_event]).to eq 'https://ecbahia.com.br/public/Inicio/'
+      expect(results[1][:local_event]).to eq 'Rua dos Elefantes, 138, CEP: 50000000, Salvador, Bahia, Brasil'
+      expect(results[1][:limit_participants]).to eq 40
+      expect(results[1][:banner]).to eq 'https://via.placeholder.com/300x200'
+      expect(results[1][:logo]).to eq 'https://via.placeholder.com/100x100'
+      expect(results[1][:description]).to eq 'Aprenda a nadar rápido'
+      expect(results[1][:event_owner]).to eq 'Cesar'
+      expect(results[1][:event_agendas]).to eq []
   
   
     end

--- a/spec/services/events_api_service_spec.rb
+++ b/spec/services/events_api_service_spec.rb
@@ -36,7 +36,7 @@ describe EventsApiService, type: :model do
   
       response = double('response', status: 200, body: events.to_json)
       allow_any_instance_of(Faraday::Connection).to receive(:get).with('http://localhost:3000/events').and_return(response)
-      result = EventsApiService.get_events
+      results = EventsApiService.get_events
   
       
 


### PR DESCRIPTION
-Cria serviço para remover a responsabilidade de fazer requisições à API de Eventos da classe Evento.

-Inclui testes unitários para o serviço.

![image](https://github.com/user-attachments/assets/0716a64c-0102-423d-8097-8a587c5e3fea)
 
resolve #50 