### PR TITLE
Feat/aplicação gera qrcode para o token do ingresso

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,8 @@ gem "tailwindcss-rails"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
 
+gem "rqrcode"
+
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    chunky_png (1.4.0)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
     cpf_cnpj (1.0.1)
@@ -257,6 +258,10 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    rqrcode (2.2.0)
+      chunky_png (~> 1.0)
+      rqrcode_core (~> 1.0)
+    rqrcode_core (1.2.0)
     rspec-core (3.13.2)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.3)
@@ -406,6 +411,7 @@ DEPENDENCIES
   propshaft
   puma (>= 5.0)
   rails (~> 8.0.1)
+  rqrcode
   rspec-rails
   rubocop-rails-omakase
   shoulda-matchers (~> 6.4)

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -25,12 +25,12 @@ class TicketsController < ApplicationController
     @ticket = Ticket.find(params[:id])
     @event = Event.request_event_by_id(@event_id)
 
-    @qrcode =   RQRCode::QRCode.new(@ticket.token)
+    @qrcode = RQRCode::QRCode.new(@ticket.token)
 
     @svg = @qrcode.as_svg(
       offset: 0,
-      color: '000',
-      shape_rendering: 'crispEdges',
+      color: "000",
+      shape_rendering: "crispEdges",
       module_size: 6,
       standalone: true
     )

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -1,6 +1,6 @@
 class TicketsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_event_and_batch, only: [ :new, :create ]
+  before_action :set_event_and_batch, only: [ :new, :create, :show ]
   def new
     @ticket = Ticket.new
   end
@@ -14,11 +14,26 @@ class TicketsController < ApplicationController
     @ticket.batch_id = @batch_id
 
     if @ticket.save
-      redirect_to root_path, notice: "Compra aprovada"
+      redirect_to event_batch_ticket_path(@event_id, @batch_id, @ticket.id), notice: "Compra aprovada"
     else
       flash.now[:notice] = "Não foi possível realizar a compra"
       render :new, status: :unprocessable_entity
     end
+  end
+
+  def show
+    @ticket = Ticket.find(params[:id])
+    @event = Event.request_event_by_id(@event_id)
+
+    @qrcode =   RQRCode::QRCode.new(@ticket.token)
+
+    @svg = @qrcode.as_svg(
+      offset: 0,
+      color: '000',
+      shape_rendering: 'crispEdges',
+      module_size: 6,
+      standalone: true
+    )
   end
 
   private

--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -1,5 +1,13 @@
 
 
-<h2>Evento: <%= @event.name %></h2>
-
-<%= @svg.html_safe %>
+<div class="w-80 mx-auto bg-white p-4 rounded-[1.25rem] mb-5 shadow-lg ">
+  <div class="text-center w-72 card-event">
+    <div class="flex justify-center items-center mb-5 h-72 mt-5 text-center">
+        <%= @svg.html_safe %>
+    </div>
+    <div class="px-3 space-y-2 text-center">
+        <h1 class="text-dark_blue text-[22px] font-bold"><h2><%= I18n.t('.event.one') %>: <%= @event.name %></h2></h1>
+        <p class="font-normal text-light_slate_gray text-normal"><%= current_user.name %></p>
+    </div>
+  </div>
+</div>

--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -1,0 +1,5 @@
+
+
+<h2>Evento: <%= @event.name %></h2>
+
+<%= @svg.html_safe %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,7 @@ Rails.application.routes.draw do
 
     resources :events, only: [ :index, :show ] do
       resources :batches, only: [ :index ] do
-        resources :tickets, only: [ :new, :create ]
+        resources :tickets, only: [ :new, :create, :show ]
       end
     end
     resources :favorites, only: [ :index, :create, :destroy ]

--- a/spec/system/tickets/user_buys_ticket_spec.rb
+++ b/spec/system/tickets/user_buys_ticket_spec.rb
@@ -37,7 +37,7 @@ describe 'Usuário é redirecionado para a tela de confimação de compra de ing
     expect(page).to have_content 'Evento: DevWeek'
     expect(ticket.batch_id).to eq batch_2.batch_id
     expect(ticket.payment_method).to eq 'pix'
-    expect(page).to have_css('sv')
+    expect(page).to have_css('svg')
   end
 
   it 'e falha por não selecionar o método de pagamento' do

--- a/spec/system/tickets/user_buys_ticket_spec.rb
+++ b/spec/system/tickets/user_buys_ticket_spec.rb
@@ -37,7 +37,7 @@ describe 'Usuário é redirecionado para a tela de confimação de compra de ing
     expect(page).to have_content 'Evento: DevWeek'
     expect(ticket.batch_id).to eq batch_2.batch_id
     expect(ticket.payment_method).to eq 'pix'
-    expect(page).to have_css('svg')
+    expect(page).to have_css('sv')
   end
 
   it 'e falha por não selecionar o método de pagamento' do

--- a/spec/system/tickets/user_buys_ticket_spec.rb
+++ b/spec/system/tickets/user_buys_ticket_spec.rb
@@ -20,9 +20,11 @@ describe 'Usuário é redirecionado para a tela de confimação de compra de ing
     travel_to(Time.zone.local(2024, 02, 01, 00, 04, 44))
     user = create(:user)
     event_1 = build(:event,  event_id: 1)
-    event_2 = build(:event,  event_id: 2)
+    event_2 = build(:event, name: 'DevWeek',  event_id: 2)
     batch_1 = build(:batch, batch_id: 1, name: "Meia-Entrada")
     batch_2 = build(:batch, batch_id: 2, name: "Pré-venda")
+
+    allow(Event).to receive(:request_event_by_id).and_return(event_2)
 
     login_as(user)
     visit new_event_batch_ticket_path(event_id: event_2.event_id, batch_id: batch_2.batch_id, locale: :'pt-BR')
@@ -32,8 +34,10 @@ describe 'Usuário é redirecionado para a tela de confimação de compra de ing
     ticket = Ticket.last
 
     expect(page).to have_content("Compra aprovada")
+    expect(page).to have_content 'Evento: DevWeek'
     expect(ticket.batch_id).to eq batch_2.batch_id
     expect(ticket.payment_method).to eq 'pix'
+    expect(page).to have_css('svg')
   end
 
   it 'e falha por não selecionar o método de pagamento' do


### PR DESCRIPTION
Implementamos no controller de tickets a geração de um qr code para ingressos que é mostrado quando entra no show de tickets. 

Também implementamos no teste de sucesso de compra do ticket, para esperar um svg dentro da pagina.
mas como foi falado anteriormente com o Otavio, não achamos uma solução para esperar o conteudo da qrcode e iremos abrir uma nova issue para resolver este teste.

página show de ingresso:

![image](https://github.com/user-attachments/assets/0be614b6-b537-43e9-bb88-64b4668d17b9)

Resolve: #12 