### PR TITLE
Adiciona endpoint que disponibiliza número de ingressos vendidos por Lote 

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,0 +1,2 @@
+class Api::V1::ApiController < ActionController::API
+end

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,2 +1,7 @@
 class Api::V1::ApiController < ActionController::API
+  rescue_from ActiveRecord::ActiveRecordError, with: :return_500
+
+  def return_500
+    render status: :internal_server_error, json: { error: "An unexpected error occurred" }
+  end
 end

--- a/app/controllers/api/v1/batches_controller.rb
+++ b/app/controllers/api/v1/batches_controller.rb
@@ -1,7 +1,18 @@
 class Api::V1::BatchesController < Api::V1::ApiController
+  before_action :set_batch_and_event
   def show
-    batch_id = params[:id].to_i
-    sold_tickets = Ticket.where(batch_id: params[:id]).count
-    render status: :ok, json: { id: batch_id, sold_tickets: sold_tickets }
+    if Batch.get_batch_by_id(@event_id, @batch_id)
+      sold_tickets = Ticket.where(batch_id: params[:id]).count
+      render status: :ok, json: { id: @batch_id, sold_tickets: sold_tickets }
+    else
+      render status: :not_found, json: { error: "Batch not found" }
+    end
+  end
+
+  private
+
+  def set_batch_and_event
+    @event_id = params[:event_id].to_i
+    @batch_id = params[:id].to_i
   end
 end

--- a/app/controllers/api/v1/batches_controller.rb
+++ b/app/controllers/api/v1/batches_controller.rb
@@ -1,11 +1,7 @@
 class Api::V1::BatchesController < Api::V1::ApiController
   def show
-    begin
-      batch_id = params[:id].to_i
-      sold_tickets = Ticket.where(batch_id: params[:id]).count
-      render status: 200, json: { id: batch_id, sold_tickets: sold_tickets }
-    rescue
-      render status: 400
-    end
+    batch_id = params[:id].to_i
+    sold_tickets = Ticket.where(batch_id: params[:id]).count
+    render status: :ok, json: { id: batch_id, sold_tickets: sold_tickets }
   end
 end

--- a/app/controllers/api/v1/batches_controller.rb
+++ b/app/controllers/api/v1/batches_controller.rb
@@ -1,0 +1,11 @@
+class Api::V1::BatchesController < Api::V1::ApiController
+  def show
+    begin
+      batch_id = params[:id].to_i
+      sold_tickets = Ticket.where(batch_id: params[:id]).count
+      render status: 200, json: { id: batch_id, sold_tickets: sold_tickets }
+    rescue
+      render status: 400
+    end
+  end
+end

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -17,6 +17,13 @@ class Batch
 
   private
 
+  def self.get_batch_by_id(event_id, batch_id)
+    batch = EventsApiService.get_batch_by_id(event_id, batch_id)
+    Batch.new(batch_id: batch[:id], name: batch[:name], limit_tickets: batch[:limit_tickets],
+              start_date: batch[:start_date].to_date, value: batch[:value], end_date: batch[:end_date].to_date,
+              event_id: batch[:event_id])
+  end
+
   def self.request_batches_by_event_id(event_id)
     batches_params = EventsApiService.get_batches_by_event_id event_id
     self.build_batches(batches_params)

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -22,6 +22,9 @@ class Batch
     Batch.new(batch_id: batch[:id], name: batch[:name], limit_tickets: batch[:limit_tickets],
               start_date: batch[:start_date].to_date, value: batch[:value], end_date: batch[:end_date].to_date,
               event_id: batch[:event_id])
+  rescue Faraday::Error => error
+    Rails.logger.error(error)
+    nil
   end
 
   def self.request_batches_by_event_id(event_id)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,4 +28,10 @@ Rails.application.routes.draw do
     resources :reminders, only: [ :create, :destroy ]
     resources :favorites, only: [ :index, :create, :destroy ]
   end
+
+  namespace :api do
+    namespace :v1 do
+        resources :batches,  only: [ :show ]
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,9 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
+      resources :events do
         resources :batches,  only: [ :show ]
+      end
     end
   end
 end

--- a/spec/requests/apis/tickets/tickets_api_spec.rb
+++ b/spec/requests/apis/tickets/tickets_api_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+describe 'Tickets API' do
+  context '[GET] /api/v1/batches/[:batch_id]' do
+    it 'com sucesso' do
+      batches = [
+        {
+        id: 1,
+        name: 'Entrada - Meia',
+        limit_tickets: 20,
+        start_date: 5.days.ago.to_date,
+        value: 20.00,
+        end_date: 2.month.from_now.to_date,
+        event_id: 1
+        },
+        {
+        id: 2,
+        name: 'PCD - Meia',
+        limit_tickets: 50,
+        start_date: 6.days.ago.to_date,
+        value: 10.00,
+        end_date: 2.month.from_now.to_date,
+        event_id: 1
+        }
+      ]
+      target_batch_id = batches[1][:id]
+
+      build(:event, name: 'DevWeek',  event_id: 1, batches: batches)
+      create(:ticket, batch_id: target_batch_id)
+      create(:ticket, batch_id: target_batch_id)
+
+      get "/api/v1/batches/#{target_batch_id}"
+
+      expect(response.status).to eq 200
+      expect(response.content_type).to include 'application/json'
+
+      json_response = JSON.parse(response.body)
+      puts "Params: #{json_response}"
+      expect(json_response["sold_tickets"]).to eq 2
+      expect(json_response["id"]).to eq 2
+    end
+  end
+end

--- a/spec/requests/apis/tickets/tickets_api_spec.rb
+++ b/spec/requests/apis/tickets/tickets_api_spec.rb
@@ -35,9 +35,98 @@ describe 'Tickets API' do
       expect(response.content_type).to include 'application/json'
 
       json_response = JSON.parse(response.body)
-      puts "Params: #{json_response}"
+
       expect(json_response["sold_tickets"]).to eq 2
       expect(json_response["id"]).to eq 2
+    end
+
+    it 'e retorna zero ingerssos vendidos quando não encontra o lote' do
+      batches = [
+        {
+        id: 2,
+        name: 'PCD - Meia',
+        limit_tickets: 50,
+        start_date: 6.days.ago.to_date,
+        value: 10.00,
+        end_date: 2.month.from_now.to_date,
+        event_id: 1
+        }
+      ]
+      target_batch_id = batches[0][:id]
+      create(:ticket, batch_id: target_batch_id)
+      invalid_batch_id = 12345678
+
+      get "/api/v1/batches/#{invalid_batch_id}"
+
+      expect(response.status).to eq 200
+      expect(response.content_type).to include 'application/json'
+
+      json_response = JSON.parse(response.body)
+
+      expect(json_response["sold_tickets"]).to eq 0
+      expect(json_response["id"]).to eq 12345678
+    end
+
+    it 'e não conta tickets de outro lote' do
+      batches = [
+        {
+        id: 1,
+        name: 'Entrada - Meia',
+        limit_tickets: 20,
+        start_date: 5.days.ago.to_date,
+        value: 20.00,
+        end_date: 2.month.from_now.to_date,
+        event_id: 1
+        },
+        {
+        id: 2,
+        name: 'PCD - Meia',
+        limit_tickets: 50,
+        start_date: 6.days.ago.to_date,
+        value: 10.00,
+        end_date: 2.month.from_now.to_date,
+        event_id: 1
+        }
+      ]
+      target_batch_id = batches[1][:id]
+      other_batch_id = batches[0][:id]
+
+      build(:event, name: 'DevWeek',  event_id: 1, batches: batches)
+      create(:ticket, batch_id: target_batch_id)
+      create(:ticket, batch_id: target_batch_id)
+      create(:ticket, batch_id: other_batch_id)
+
+      get "/api/v1/batches/#{target_batch_id}"
+
+      expect(response.status).to eq 200
+      expect(response.content_type).to include 'application/json'
+
+      json_response = JSON.parse(response.body)
+
+      expect(json_response["sold_tickets"]).to eq 2
+      expect(json_response["id"]).to eq 2
+    end
+
+    it 'E falha com um erro interno' do
+      batches = [
+        {
+        id: 2,
+        name: 'PCD - Meia',
+        limit_tickets: 50,
+        start_date: 6.days.ago.to_date,
+        value: 10.00,
+        end_date: 2.month.from_now.to_date,
+        event_id: 1
+        }
+      ]
+      target_batch_id = batches[0][:id]
+      create(:ticket, batch_id: target_batch_id)
+      invalid_batch_id = 12345678
+      allow(Ticket).to receive(:where).and_raise(ActiveRecord::QueryCanceled)
+
+      get "/api/v1/batches/#{invalid_batch_id}"
+
+      expect(response.status).to eq 500
     end
   end
 end

--- a/spec/requests/apis/tickets/tickets_api_spec.rb
+++ b/spec/requests/apis/tickets/tickets_api_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'Tickets API' do
-  context '[GET] /api/v1/batches/[:batch_id]' do
+  context 'Retorna quantidade de Ingressos vendidos por Lote' do
     it 'com sucesso' do
       batches = [
         {


### PR DESCRIPTION
**Descrição**:

Adiciona endpoit para visualização de número de ingressos por lote: (` api/v1/batch/[:batch_id]` )

Adiciona teste de requisição.
Retorno da requisição:


![image](https://github.com/user-attachments/assets/e8f4a328-2457-45fc-b3bc-86ecc9918103)

resolve: #81 