### PR TITLE
Implementa vizualização de um post no feed de um evento

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,11 @@
 class PostsController < ApplicationController
   before_action :authenticate_user!
   before_action :check_user_is_participant
+
+  def show
+    @post = Post.find(params[:id])
+  end
+
   def new
     @post = Post.new
     @event_id = params[:event_id]

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -96,7 +96,7 @@
       <ul class="space-y-4">
         <% @posts.each do |post| %>
           <li class="bg-white shadow-md rounded-lg transition hover:shadow-lg">
-            <%= link_to event_post_path(@event, post), class: "block p-6" do %>
+            <%= link_to event_post_path(@event.event_id, post), class: "block p-6" do %>
               <h3 class="text-xl font-semibold text-gray-900"><%= post.title %></h3>
               <p class="mt-1 text-sm text-gray-500">
                 <%= l(post.created_at, format: :short) %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -97,7 +97,7 @@
           <% if @posts.any? %>
             <% @posts.each do |post| %>
               <li class="bg-white shadow-md rounded-lg transition hover:shadow-lg">
-                <%= link_to event_post_path(@event, post), class: "block p-6" do %>
+                <%= link_to event_post_path(@event.event_id, post), class: "block p-6" do %>
                   <h3 class="text-xl font-semibold text-gray-900"><%= post.title %></h3>
                   <p class="mt-1 text-sm text-gray-500"><%= l(post.created_at, format: :short) %></p>
                 <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,0 +1,4 @@
+<%= page_title(@post.title) %>
+
+<%= @post.content %>
+<%= l(@post.created_at, format: :short)%>

--- a/spec/system/posts/user_view_post_spec.rb
+++ b/spec/system/posts/user_view_post_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+describe 'Participante vê postagem' do
+  it 'a partir dos detalhes de um evento' do
+    event = build(:event, event_id: '1', name: 'DevWeek')
+    events = [ event ]
+    ticket = create(:ticket, event_id: event.event_id)
+    user = ticket.user
+    post = create(:post, user: user, event_id: event.event_id, title: 'Título Teste', content: '<b>Conteúdo Teste</b>')
+    allow(Event).to receive(:request_event_by_id).and_return(event)
+    allow(Event).to receive(:all).and_return(events)
+
+    login_as user
+    visit root_path
+    within 'nav' do
+      click_on 'Eventos'
+    end
+    click_on 'DevWeek'
+    click_on 'Título Teste'
+
+    expect(page).to have_content 'Título Teste'
+    expect(page).to have_content 'Conteúdo Teste'
+    expect(page).to have_content "#{I18n.l(post.created_at, format: :short)}"
+  end
+
+  it 'e não está autenticado' do
+    event = build(:event, event_id: '1', name: 'DevWeek')
+    create(:ticket, event_id: event.event_id)
+    post = create(:post, event_id: event.event_id, title: 'Título Teste', content: '<b>Conteúdo Teste</b>')
+
+    visit event_post_path(event_id: event.event_id, id: post)
+
+    expect(current_path).to eq new_user_session_path
+  end
+
+  it 'e não participa deste evento' do
+    user = create(:user)
+    event = build(:event, event_id: '1', name: 'DevWeek')
+    post = create(:post, event_id: event.event_id, title: 'Título Teste', content: '<b>Conteúdo Teste</b>')
+
+    login_as user
+    visit event_post_path(event_id: event.event_id, id: post)
+
+    expect(current_path).to eq root_path
+    expect(page).to have_content 'Você não participa deste evento'
+  end
+
+  it 'de outro participante do evento' do
+    user = create(:user)
+    event = build(:event, event_id: '1', name: 'DevWeek')
+    create(:ticket, user: user, event_id: event.event_id)
+    post = create(:post, event_id: event.event_id, title: 'Título Teste', content: '<b>Conteúdo Teste</b>')
+
+    login_as user
+    visit event_post_path(event_id: event.event_id, id: post)
+
+    expect(current_path).to eq event_post_path(event_id: event.event_id, id: post)
+    expect(page).to have_content 'Título Teste'
+    expect(page).to have_content 'Conteúdo Teste'
+    expect(page).to have_content "#{I18n.l(post.created_at, format: :short)}"
+  end
+end


### PR DESCRIPTION
- Usuário participante vê postagem no feed de um evento.

![failures_r_spec_example_groups_participante_v_postagem_a_partir_dos_detalhes_de_um_evento_304](https://github.com/user-attachments/assets/52205e69-342f-40e3-8793-055dba8185fd)
 resolve #102 