### PR TITLE
Acrescenta dados de participantes na rota total de inscritos

### DIFF
--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -5,9 +5,12 @@ class Api::V1::EventsController < Api::V1::ApiController
       return render status: :not_found, json: { error: "Event not found" }
     end
     sold_tickets = Ticket.where(event_id: event_id).count
-    render status: :ok, json: {
+    participants = User.joins(:tickets).where(tickets: { event_id: event_id })
+     participants = participants.map { |participant| { name: participant.name, last_name: participant.last_name, email: participant.email, cpf: participant.cpf } }
+     render status: :ok, json: {
       id: event_id,
-      sold_tickets: sold_tickets
+      sold_tickets: sold_tickets,
+      participants: participants
     }
   end
 end


### PR DESCRIPTION
Refatora testes da rota de eventos e inclui dados de participante na rota que entrega total de tickets vendidos para um evento.

Dados de participants adicionado:
![image](https://github.com/user-attachments/assets/c07f1003-8eb1-4adb-86f8-4ce2c4d43a15)

Resolve #107 