### PR TITLE
Cria Select de cidades e Estados na página de perfil de usuário

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ gem "faraday", "~> 2.12"
 
 group :test do
   gem "shoulda-matchers", "~> 6.4"
+  gem "webmock"
 end
 
 gem "cpf_cnpj", "~> 1.0"

--- a/Gemfile
+++ b/Gemfile
@@ -67,3 +67,5 @@ group :test do
 end
 
 gem "cpf_cnpj", "~> 1.0"
+
+gem "carmen"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,9 @@ GEM
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
     cpf_cnpj (1.0.1)
+    crack (1.0.0)
+      bigdecimal
+      rexml
     crass (1.0.6)
     cuprite (0.15.1)
       capybara (~> 3.0)
@@ -146,6 +149,7 @@ GEM
       raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    hashdiff (1.1.2)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     image_processing (1.13.0)
@@ -269,6 +273,7 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    rexml (3.4.0)
     rqrcode (2.2.0)
       chunky_png (~> 1.0)
       rqrcode_core (~> 1.0)
@@ -387,6 +392,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webmock (3.24.0)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.9.1)
     websocket-driver (0.7.7)
       base64
@@ -439,6 +448,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
+  webmock
 
 BUNDLED WITH
    2.6.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    carmen (1.1.3)
+      activesupport (>= 3.0.0)
     chunky_png (1.4.0)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
@@ -132,7 +134,13 @@ GEM
       concurrent-ruby (~> 1.1)
       webrick (~> 1.7)
       websocket-driver (~> 0.7)
+    ffi (1.17.1-aarch64-linux-gnu)
+    ffi (1.17.1-aarch64-linux-musl)
+    ffi (1.17.1-arm-linux-gnu)
+    ffi (1.17.1-arm-linux-musl)
+    ffi (1.17.1-arm64-darwin)
     ffi (1.17.1-x86_64-linux-gnu)
+    ffi (1.17.1-x86_64-linux-musl)
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
@@ -403,6 +411,7 @@ PLATFORMS
 DEPENDENCIES
   brakeman
   capybara
+  carmen
   cpf_cnpj (~> 1.0)
   cuprite
   debug

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -5,7 +5,11 @@ class ProfilesController < ApplicationController
 
   def show; end
 
-  def edit; end
+  def edit
+    br = Carmen::Country.coded("BR")
+
+    @states = br.subregions
+  end
 
   def update
     if @profile.update(profile_params)

--- a/app/javascript/controllers/cities_controller.js
+++ b/app/javascript/controllers/cities_controller.js
@@ -1,0 +1,27 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+
+    
+ async selectCity(event) {
+     try {     
+      const optionsCity = document.querySelector('.cities')
+      optionsCity.innerHTML = ''
+      const nameSate =  event.target.value
+      const states = await fetch("https://brasilapi.com.br/api/ibge/uf/v1")
+      const dataStates = await states.json()
+
+      const uf = dataStates.find((state) => state.nome == nameSate).sigla
+      const cities = await fetch(`https://brasilapi.com.br/api/ibge/municipios/v1/${uf}`)
+      const dataCities = await cities.json()
+      dataCities.forEach(city => {
+        const option = document.createElement('option');
+        option.textContent = city.nome;
+        option.value = city.nome;
+        optionsCity.appendChild(option);
+      });
+    } catch (error) {
+      console.error('Erro ao carregar as cidades:', error);
+    }
+  }
+}

--- a/app/javascript/controllers/cities_controller.js
+++ b/app/javascript/controllers/cities_controller.js
@@ -10,7 +10,6 @@ export default class extends Controller {
       const nameSate =  event.target.value
       const states = await fetch("https://brasilapi.com.br/api/ibge/uf/v1")
       const dataStates = await states.json()
-
       const uf = dataStates.find((state) => state.nome == nameSate).sigla
       const cities = await fetch(`https://brasilapi.com.br/api/ibge/municipios/v1/${uf}`)
       const dataCities = await cities.json()

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -4,17 +4,23 @@
       <%= form_title(t('.title')) %>
       <%= form_with(model: [@user, @profile], class: 'mt-8 mb-2 w-80 max-w-screen-lg sm:w-96') do |f| %>
         <div class="mb-1 flex flex-col gap-6">
+
+          <div class="w-full" data-controller="cities">
+            <%= f.label :state, class: 'form-label' %>
+            <%= f.select :state, 
+                  options_for_select(@states), 
+                  { prompt: "Selecione um estado" }, 
+                  class: "form-field", 
+                  data: { action: "change->cities#selectCity" } %>
+          </div>
           <div class="w-full">
             <%= f.label :city, class: 'form-label' %>
-            <%= f.text_field :city, class: 'form-field' %>
+            <%= f.select :city, 
+                  options_for_select([]), 
+                  { prompt: "Selecione uma cidade" }, 
+                  class: "form-field cities", 
+                  data: { action: "change->cities#selectCity" } %>    
           </div>
-
-          <div class="w-full">
-            <%= f.label :state, class: 'form-label' %>
-            <%= f.select :payment_method, options_for_select(@states.map { |state| [state.name, state.code]}), { prompt: true },
-            { class: "form-field" } %>
-          </div>
-
           <div class="w-full">
             <%= f.label :phone_number, class: 'form-label' %>
             <%= f.text_field :phone_number, class: 'form-field' %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -11,7 +11,8 @@
 
           <div class="w-full">
             <%= f.label :state, class: 'form-label' %>
-            <%= f.text_field :state, class: 'form-field' %>
+            <%= f.select :payment_method, options_for_select(@states.map { |state| [state.name, state.code]}), { prompt: true },
+            { class: "form-field" } %>
           </div>
 
           <div class="w-full">

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -49,6 +49,16 @@ RSpec.configure do |config|
   #     browser_options: { "no-sandbox" => nil }
   #   })
   # end
+  config.before(:each, type: :system, js: true) do
+    driven_by(:cuprite, screen_size: [1440, 810], options: {
+      js_errors: false,
+      headless: true,  # A opção headless faz o navegador rodar sem abrir uma janela visível
+      process_timeout: 25,
+      timeout: 20,
+      browser_options: { "no-sandbox" => nil }  # Recomendado para contornar problemas com Docker ou CI
+    })
+  end
+
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,8 @@
 # it.
 #
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+require 'webmock/rspec'
+WebMock.disable_net_connect!(allow_localhost: true)
 RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate

--- a/spec/system/profiles/user_edit_profile_spec.rb
+++ b/spec/system/profiles/user_edit_profile_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'webmock/rspec'
 
 describe 'usuário edita perfil' do
   it 'pela página do perfil' do
@@ -16,18 +15,11 @@ describe 'usuário edita perfil' do
   it 'com sucesso', type: :system, js: true do
     user = create(:user, email: 'teste@email.com')
 
-    stub_request(:get, "https://brasilapi.com.br/api/ibge/uf/v1")
-      .to_return(status: 200, body: '[{"nome": "Bahia", "sigla": "BA"}]', headers: {})
-
-    stub_request(:get, "https://brasilapi.com.br/api/ibge/municipios/v1/BA")
-      .to_return(status: 200, body: '[{"nome": "Salvador"}, {"nome": "Feira de Santana"}]', headers: {})
-
     login_as user
     visit edit_user_profile_path(user_id: user, id: user.profile)
     select 'Bahia', from: 'Estado'
 
     select 'SALVADOR', from: 'Cidade'
-
     fill_in 'Telefone', with: '11912125454'
     click_on 'Salvar Informações'
 
@@ -37,7 +29,6 @@ describe 'usuário edita perfil' do
     expect(page).to have_content 'SALVADOR'
     expect(page).to have_content '11912125454'
   end
-
 
   it 'e não está logado' do
     user = create(:user)

--- a/spec/system/profiles/user_edit_profile_spec.rb
+++ b/spec/system/profiles/user_edit_profile_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'webmock/rspec'
 
 describe 'usuário edita perfil' do
   it 'pela página do perfil' do
@@ -12,22 +13,31 @@ describe 'usuário edita perfil' do
     expect(page).to have_link 'Editar Perfil'
   end
 
-  it 'com sucesso' do
+  it 'com sucesso', type: :system, js: true do
     user = create(:user, email: 'teste@email.com')
+
+    stub_request(:get, "https://brasilapi.com.br/api/ibge/uf/v1")
+      .to_return(status: 200, body: '[{"nome": "Bahia", "sigla": "BA"}]', headers: {})
+
+    stub_request(:get, "https://brasilapi.com.br/api/ibge/municipios/v1/BA")
+      .to_return(status: 200, body: '[{"nome": "Salvador"}, {"nome": "Feira de Santana"}]', headers: {})
 
     login_as user
     visit edit_user_profile_path(user_id: user, id: user.profile)
-    fill_in 'Cidade', with: 'TesteCidade'
-    fill_in 'Estado', with: 'TesteEstado'
+    select 'Bahia', from: 'Estado'
+
+    select 'SALVADOR', from: 'Cidade'
+
     fill_in 'Telefone', with: '11912125454'
     click_on 'Salvar Informações'
 
     expect(current_path).to eq user_profile_path(user_id: user, id: user.profile, locale: :'pt-BR')
     expect(page).to have_content 'Perfil atualizado'
-    expect(page).to have_content 'TesteCidade'
-    expect(page).to have_content 'TesteEstado'
+    expect(page).to have_content 'Bahia'
+    expect(page).to have_content 'SALVADOR'
     expect(page).to have_content '11912125454'
   end
+
 
   it 'e não está logado' do
     user = create(:user)


### PR DESCRIPTION
Adiciona stimulus js para manipulação de select de opções de cidades e estados para o usuário na hora de personalizar seu perfil.
![Captura de tela de 2025-02-02 14-23-16](https://github.com/user-attachments/assets/f8986af4-8308-4362-b707-9249e98c5461)


Resolve #42 