### PR TITLE
Criada API de feedbacks de um evento e seus testes

### DIFF
--- a/app/controllers/api/v1/feedbacks_controller.rb
+++ b/app/controllers/api/v1/feedbacks_controller.rb
@@ -1,0 +1,23 @@
+class Api::V1::FeedbacksController < Api::V1::ApiController
+  before_action :set_and_check_event
+
+  def index
+    @feedbacks = Feedback.where(event_id: @event.event_id)
+    if @feedbacks.any?
+      feedback_json = @feedbacks.map { |feedback| { id: feedback.id, title: feedback.title,
+                                                    comment: feedback.comment, mark: feedback.mark,
+                                                    user: feedback.user.full_name } }
+      render status: :ok, json: { event_id: @event.event_id, feedbacks: feedback_json }
+    else
+      render status: :not_found, json: { event_id: @event.event_id, error: "There is no feedbacks to this event yet" }
+    end
+  end
+
+  private
+
+  def set_and_check_event
+    @event = Event.request_event_by_id(params[:event_id])
+    return render status: :not_found, json: { error: "Event not found" } unless @event
+    render status: :not_found, json: { event_id: @event.event_id, error: "This event is still ongoing" } if @event.end_date >= Date.today
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,10 @@ class User < ApplicationRecord
     Ticket.where(user: self, event_id: event_id).any?
   end
 
+  def full_name
+    self.name + " "  + self.last_name
+  end
+
   private
 
   def create_profile

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :events, only: [ :show ] do
         resources :batches,  only: [ :show ]
+        resources :feedbacks,  only: [ :index ]
       end
     end
   end

--- a/spec/factories/feedbacks.rb
+++ b/spec/factories/feedbacks.rb
@@ -2,7 +2,8 @@ FactoryBot.define do
   factory :feedback do
     event_id { "1" }
     user
-    coment { "MyString" }
+    title { "Título Padrão" }
+    comment { "Comentário Padrão" }
     mark { 1 }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -48,6 +48,16 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '#full_name' do
+    it 'retorna o nome completo do usuário' do
+      user = create(:user, name: 'teste', last_name: 'não teste')
+
+      result = user.full_name
+
+      expect(result).to eq 'teste não teste'
+    end
+  end
+
   describe 'validations' do
     context 'Nome de Usuário' do
       it { is_expected.to validate_presence_of(:name) }

--- a/spec/requests/apis/feedbacks/feedbacks_api_spec.rb
+++ b/spec/requests/apis/feedbacks/feedbacks_api_spec.rb
@@ -1,0 +1,108 @@
+require 'rails_helper'
+
+describe 'Feedback API' do
+  context 'Retorna os feedback de um evento' do
+    it 'com sucesso' do
+      user = create(:user, name: 'Gabriel', last_name: 'Tavares')
+      other_user = create(:user, name: 'David', last_name: 'Martinez')
+      event = build(:event, event_id: '1', start_date: 5.days.ago, end_date: 5.days.from_now, name: 'DevWeek')
+      create(:ticket, event_id: event.event_id, user: user)
+      create(:ticket, event_id: event.event_id, user: other_user)
+      allow(Event).to receive(:request_event_by_id).and_return(event)
+      travel_to 6.days.from_now do
+        login_as user
+        create(:feedback, title: 'Título', comment: 'Comentário', mark: 4, event_id: event.event_id,
+               user: user, public: false)
+        login_as other_user
+        create(:feedback, title: 'Título Padrão', comment: 'Comentário Padrão', mark: 3, event_id: event.event_id,
+               user: other_user, public: true)
+
+        get "/api/v1/events/#{event.event_id}/feedbacks"
+
+        expect(response.status).to eq 200
+        expect(response.content_type).to include 'application/json'
+        json_response = JSON.parse(response.body)
+        expect(json_response["event_id"]).to eq '1'
+        expect(json_response["feedbacks"][0]["id"]).to eq 1
+        expect(json_response["feedbacks"][0]["title"]).to eq 'Título'
+        expect(json_response["feedbacks"][0]["comment"]).to eq 'Comentário'
+        expect(json_response["feedbacks"][0]["mark"]).to eq 4
+        expect(json_response["feedbacks"][0]["user"]).to eq 'Gabriel Tavares'
+        expect(json_response["feedbacks"][1]["id"]).to eq 2
+        expect(json_response["feedbacks"][1]["title"]).to eq 'Título Padrão'
+        expect(json_response["feedbacks"][1]["comment"]).to eq 'Comentário Padrão'
+        expect(json_response["feedbacks"][1]["mark"]).to eq 3
+        expect(json_response["feedbacks"][1]["user"]).to eq 'David Martinez'
+      end
+    end
+
+    it 'e retorna 404 se não encontra evento' do
+      user = create(:user, name: 'Gabriel', last_name: 'Tavares')
+      other_user = create(:user, name: 'David', last_name: 'Martinez')
+      event = build(:event, event_id: '1', start_date: 5.days.ago, end_date: 5.days.from_now, name: 'DevWeek')
+      travel_to 6.days.from_now do
+        create(:ticket, event_id: event.event_id, user: user)
+        create(:ticket, event_id: event.event_id, user: other_user)
+        allow(Event).to receive(:request_event_by_id).and_return(nil)
+
+        get "/api/v1/events/9999/feedbacks"
+
+        expect(response.status).to eq 404
+        expect(response.content_type).to include 'application/json'
+        json_response = JSON.parse(response.body)
+        expect(json_response["error"]).to eq 'Event not found'
+      end
+    end
+
+    it 'e retorna mensagem quando não existem feedbacks disponíveis' do
+      event = build(:event, event_id: '1', start_date: 5.days.ago, end_date: 5.days.from_now, name: 'DevWeek')
+      allow(Event).to receive(:request_event_by_id).and_return(event)
+
+      travel_to 6.days.from_now do
+        get "/api/v1/events/#{event.event_id}/feedbacks"
+
+        expect(response.status).to eq 404
+        expect(response.content_type).to include 'application/json'
+        json_response = JSON.parse(response.body)
+        expect(json_response["event_id"]).to eq '1'
+        expect(json_response["error"]).to eq 'There is no feedbacks to this event yet'
+      end
+    end
+
+    it 'e retorna mensagem personalizado quando o evento ainda está em andamento' do
+      event = build(:event, event_id: '1', start_date: 5.days.ago, end_date: 5.days.from_now, name: 'DevWeek')
+      allow(Event).to receive(:request_event_by_id).and_return(event)
+
+      get "/api/v1/events/#{event.event_id}/feedbacks"
+
+      expect(response.status).to eq 404
+      expect(response.content_type).to include 'application/json'
+      json_response = JSON.parse(response.body)
+      expect(json_response["event_id"]).to eq '1'
+      expect(json_response["error"]).to eq 'This event is still ongoing'
+    end
+
+    it 'E falha com um erro interno' do
+      user = create(:user, name: 'Gabriel', last_name: 'Tavares')
+      other_user = create(:user, name: 'David', last_name: 'Martinez')
+      event = build(:event, event_id: '1', start_date: 5.days.ago, end_date: 5.days.from_now, name: 'DevWeek')
+      create(:ticket, event_id: event.event_id, user: user)
+      create(:ticket, event_id: event.event_id, user: other_user)
+      allow(Event).to receive(:request_event_by_id).and_return(event)
+      allow(Feedback).to receive(:where).and_raise(ActiveRecord::QueryCanceled)
+
+      travel_to 6.days.from_now do
+        login_as user
+        create(:feedback, title: 'Título', comment: 'Comentário', mark: 4, event_id: event.event_id,
+               user: user, public: false)
+        login_as other_user
+        create(:feedback, title: 'Título Padrão', comment: 'Comentário Padrão', mark: 3, event_id: event.event_id,
+               user: other_user, public: true)
+
+        get "/api/v1/events/#{event.event_id}/feedbacks"
+
+        expect(response.status).to eq 500
+      end
+    end
+  end
+end


### PR DESCRIPTION
API de feedbacks que lista todos os feedbacks de um evento em específico.

1. Retorna not found se evento não existe
2. Retorna There is no feedback yet to this event se não houverem feedback
3. Retorna This event is still ongoing se evento ainda não acabou
Resolve #22