### PR TITLE
Refatoração dos controllers e traduções

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,4 +27,10 @@ class ApplicationController < ActionController::Base
   def default_url_options
     { locale: I18n.locale }
   end
+
+  def check_user_is_participant(event_id)
+    unless current_user.participates_in_event?(event_id)
+      redirect_to root_path, alert: I18n.t("custom.generic.negate_access")
+    end
+  end
 end

--- a/app/controllers/batches_controller.rb
+++ b/app/controllers/batches_controller.rb
@@ -1,5 +1,6 @@
 class BatchesController < ApplicationController
   before_action :authenticate_user!
+
   def index
     @batches = Batch.request_batches_by_event_id(params[:event_id])
     @event = Event.request_event_by_id(params[:event_id])

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,7 +1,7 @@
 class CommentsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_post_and_event, only: [ :create ]
-  before_action :check_user_is_participant, only: [ :create ]
+  before_action -> { check_user_is_participant(@event_id) }, only: [ :create ]
 
   def create
     @comment = Comment.new(user: current_user, **params.require(:comment).permit(:content), post: @post)
@@ -19,11 +19,5 @@ class CommentsController < ApplicationController
   def set_post_and_event
     @post = Post.find(params[:post_id])
     @event_id = params[:event_id]
-  end
-
-  def check_user_is_participant
-    unless current_user.participates_in_event?(params[:event_id])
-      redirect_to root_path, alert: t(".negate_access")
-    end
   end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,5 +1,6 @@
 class DashboardController < ApplicationController
   before_action :authenticate_user!
+
   def index
     event_ids = current_user.tickets.where(status_confirmed: true).map(&:event_id)
     @posts = Post.where(event_id: event_ids).order(created_at: :desc).limit(10)

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,5 +1,6 @@
 class EventsController < ApplicationController
   before_action :check_event, only: [ :show ]
+
   def show
     if @event.batches.any?
       batch_ids = @event.batches.map(&:batch_id)

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,5 +1,6 @@
 class FavoritesController < ApplicationController
   before_action :check_if_user_is_authenticated, only: [ :create, :index, :destroy ]
+
   def create
     @favorite = current_user.favorites.build(event_id: params[:event_id])
     if @favorite.save

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -1,7 +1,7 @@
 class FeedbacksController < ApplicationController
   before_action :authenticate_user!
   before_action :set_and_check_my_event_id
-  before_action :check_user_is_participant
+  before_action -> { check_user_is_participant(@my_event_id) }
 
   def new
     @feedback = Feedback.new
@@ -28,12 +28,6 @@ class FeedbacksController < ApplicationController
 
   def feedback_params
     params.require(:feedback).permit(:title, :comment, :mark, :public)
-  end
-
-  def check_user_is_participant
-    unless current_user.participates_in_event?(@my_event_id)
-      redirect_to root_path, alert: t(".no_ticket")
-    end
   end
 
   def set_and_check_my_event_id

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,6 +1,6 @@
 class LikesController < ApplicationController
   before_action :authenticate_user!
-  before_action :check_user_is_participant
+  before_action -> { check_user_is_participant(params[:event_id]) }
   before_action :check_user_owns_like, only: [ :destroy ]
 
   def create
@@ -18,10 +18,6 @@ class LikesController < ApplicationController
   end
 
   private
-
-  def check_user_is_participant
-    redirect_to root_path, alert: t(".negate_access") unless current_user.participates_in_event?(params[:event_id])
-  end
 
   def check_user_owns_like
     unless current_user == Like.find(params[:id]).user

--- a/app/controllers/my_events_controller.rb
+++ b/app/controllers/my_events_controller.rb
@@ -1,6 +1,7 @@
 class MyEventsController < ApplicationController
   before_action :authenticate_user!
-  before_action :check_user, only: [ :show ]
+  before_action -> { check_user_is_participant(params[:id]) }, only: [ :show ]
+
   def index
     event_ids = current_user.tickets.pluck(:event_id).uniq
     @my_events = event_ids.map { |event_id| Event.request_event_by_id(event_id) }.select { |event| event_ids.include?(event.event_id) }
@@ -10,9 +11,5 @@ class MyEventsController < ApplicationController
     @tickets_by_batch_id = Ticket.where(user: current_user, event_id: params[:id]).group_by { |event| event.batch_id }
     @batches = @tickets_by_batch_id.keys.each_with_object(Hash.new) { |batch_id, hash| hash[batch_id] = Batch.request_batch_by_id(params[:id], batch_id) }
     @event = Event.request_event_by_id(params[:id])
-  end
-
-  def check_user
-    redirect_to root_path, alert: t(".negate_access") if Ticket.where(user: current_user, event_id: params[:id]).empty?
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,7 +1,7 @@
 class PostsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_post_and_event_id, only: [ :show, :edit, :update ]
-  before_action :check_user_is_participant
+  before_action -> { check_user_is_participant(params[:event_id]) }
   before_action :set_event_id, only: [ :new, :create ]
   before_action :check_user_owns_post, only: [ :edit, :update ]
 
@@ -58,12 +58,6 @@ class PostsController < ApplicationController
   def check_user_owns_post
     unless @post.user == current_user
       redirect_to root_path, alert: t(".not_post_owner")
-    end
-  end
-
-  def check_user_is_participant
-    unless current_user.participates_in_event?(params[:event_id])
-      redirect_to root_path, alert: t(".not_participant")
     end
   end
 end

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -17,7 +17,7 @@ class TicketsController < ApplicationController
     @ticket.event_id = @event_id
 
     if @ticket.save
-      redirect_to event_batch_ticket_path(@event_id, @batch_id, @ticket.id), notice: "Compra aprovada"
+      redirect_to event_batch_ticket_path(@event_id, @batch_id, @ticket.id), notice: t(".success")
     else
       flash.now[:notice] = t(".error")
       render :new, status: :unprocessable_entity

--- a/config/locales/custom/generic/en.yml
+++ b/config/locales/custom/generic/en.yml
@@ -1,6 +1,7 @@
 en:
   custom:
     generic:
+      negate_access: You do not participate in this event
       event_not_found: Event not found
       batches_not_found: This event do not have tickets yet
       copyright: © Copyright 2025 Participants | All rights reserved

--- a/config/locales/custom/generic/pt-BR.yml
+++ b/config/locales/custom/generic/pt-BR.yml
@@ -1,6 +1,7 @@
 pt-BR:
   custom:
     generic:
+      negate_access: Você não participa deste evento
       event_not_found: Evento não encontrado
       batches_not_found: Evento ainda não possui ingressos
       copyright: © Copyright 2025 Participants | Todos os direitos reservados

--- a/config/locales/views/comments/en.yml
+++ b/config/locales/views/comments/en.yml
@@ -1,6 +1,5 @@
 en:
   comments:
-    negate_access: You do not participate in this event
     new:
       save_comment: Save Comment
     create:

--- a/config/locales/views/comments/pt-BR.yml
+++ b/config/locales/views/comments/pt-BR.yml
@@ -1,6 +1,5 @@
 pt-BR:
   comments:
-    negate_access: Você não participa deste evento
     new:
       save_comment: Adicionar Comentário
     create:

--- a/config/locales/views/feedbacks/en.yml
+++ b/config/locales/views/feedbacks/en.yml
@@ -1,7 +1,6 @@
 en:
   feedbacks:
     new:
-      no_ticket: You are not participating in this event
       title: Add your review
       save: Add Feedback
       no_finished: This event is still ongoing

--- a/config/locales/views/feedbacks/pt-BR.yml
+++ b/config/locales/views/feedbacks/pt-BR.yml
@@ -1,7 +1,6 @@
 pt-BR:
   feedbacks:
     new:
-      no_ticket: Vocẽ não participa deste evento
       title: Adicione sua avaliação
       save: Adicionar Feedback
       no_finished: Este evento ainda está em andamento

--- a/config/locales/views/likes/en.yml
+++ b/config/locales/views/likes/en.yml
@@ -1,6 +1,5 @@
 en:
   likes:
-    negate_access: You do not participate in this event
     not_like_owner: You can not remove this like
     create:
       success: You liked the post

--- a/config/locales/views/likes/pt-BR.yml
+++ b/config/locales/views/likes/pt-BR.yml
@@ -1,6 +1,5 @@
 pt-BR:
   likes:
-    negate_access: Você não participa deste evento
     not_like_owner: Você não pode remover a curtida desta postagem
     create:
       success: Você curtiu a postagem com sucesso

--- a/config/locales/views/my_events/en.yml
+++ b/config/locales/views/my_events/en.yml
@@ -1,6 +1,5 @@
 en:
   my_events:
-    negate_access: You do not have access to this event
     index:
       title: My Events
       no_tickets: You have not purchased any tickets yet

--- a/config/locales/views/my_events/pt-BR.yml
+++ b/config/locales/views/my_events/pt-BR.yml
@@ -1,6 +1,5 @@
 pt-BR:
   my_events:
-    negate_access: Você não participa deste evento!
     index:
       title: Meus Eventos
       no_tickets: Você ainda não possui ingressos comprados

--- a/config/locales/views/posts/en.yml
+++ b/config/locales/views/posts/en.yml
@@ -2,7 +2,6 @@ en:
   posts:
     not_post_owner: You can not access this page
     not_participant: You can not do that
-    negate_access: You can not do that
     show:
       edit_post: Edit
       published_in: 'Published in:'

--- a/config/locales/views/posts/pt-BR.yml
+++ b/config/locales/views/posts/pt-BR.yml
@@ -1,6 +1,5 @@
 pt-BR:
   posts:
-    negate_access: Você não participa deste evento
     not_post_owner: Você não tem acesso a essa página
     not_participant: Você não participa deste evento
     show:

--- a/config/locales/views/tickets/en.yml
+++ b/config/locales/views/tickets/en.yml
@@ -1,7 +1,7 @@
 en:
   tickets:
     create:
-      approved: Purchase approved
+      success: Purchase approved
       error: Unable to make purchase
     check_batch_is_sold_out?:
       alert: Tickets sold out

--- a/config/locales/views/tickets/pt-BR.yml
+++ b/config/locales/views/tickets/pt-BR.yml
@@ -1,7 +1,7 @@
 pt-BR:
   tickets:
     create:
-      approved: Compra aprovada
+      success: Compra aprovada
       error: Não foi possível realizar a compra
     check_batch_is_sold_out?:
       alert: Ingressos esgotados

--- a/spec/system/feedbacks/user_add_feedback_spec.rb
+++ b/spec/system/feedbacks/user_add_feedback_spec.rb
@@ -79,7 +79,7 @@ describe 'Usuário cria feedback de um evento' do
       visit new_my_event_feedback_path(my_event_id: event.event_id)
 
       expect(current_path).to eq root_path
-      expect(page).to have_content 'Vocẽ não participa deste evento'
+      expect(page).to have_content 'Você não participa deste evento'
     end
   end
 


### PR DESCRIPTION
Refatoração dos controllers para diminuir repetição de métodos que se encontravam em vários controllers diferentes, e diminuição de traduções necessárias.