### PR TITLE
Cancela migração de announcement e puxa dados de api

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -6,7 +6,7 @@ class EventsController < ApplicationController
       @total_tickets_sales = Ticket.where(batch_id: batch_ids).count
     end
     @posts = Post.where(event_id: params[:event_id])
-    @announcements = Announcement.where(event_id: params[:event_id])
+    @announcements = []
   end
 
   def index

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -6,7 +6,7 @@ class EventsController < ApplicationController
       @total_tickets_sales = Ticket.where(batch_id: batch_ids).count
     end
     @posts = Post.where(event_id: params[:event_id])
-    @announcements = []
+    @announcements = @event.announcements
   end
 
   def index

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -1,3 +1,10 @@
-class Announcement < ApplicationRecord
-  validates :event_id, :title, :content, presence: true
+class Announcement
+  attr_accessor :event_id, :announcement_id, :title, :description
+
+  def initialize(event_id:, announcement_id:, title:, description:)
+    @event_id = event_id
+    @title = title
+    @description = description
+    @announcement_id = announcement_id
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,6 @@
 class Event
-  attr_accessor :name, :banner, :logo, :event_id, :event_owner, :local_event, :description, :url_event, :limit_participants, :start_date, :end_date, :batches, :schedules
-  def initialize(event_id:, name:, banner:, logo:, event_owner:, url_event:, local_event:, limit_participants:, description:, start_date:, end_date:, batches:, schedules:)
+  attr_accessor :name, :banner, :logo, :event_id, :event_owner, :local_event, :description, :url_event, :limit_participants, :start_date, :end_date, :batches, :schedules, :announcements
+  def initialize(event_id:, name:, banner:, logo:, event_owner:, url_event:, local_event:, limit_participants:, description:, start_date:, end_date:, batches:, schedules:, announcements:)
     @event_id = event_id
     @name = name
     @banner = banner
@@ -14,6 +14,7 @@ class Event
     @description = description
     @schedules = build_schedules(schedules)
     @batches = build_batch(batches)
+    @announcements = build_announcement(announcements)
   end
 
   def self.all
@@ -73,7 +74,8 @@ class Event
     Event.new(
       event_id: data[:code], name: data[:name], banner: data[:banner_url], logo: data[:logo_url], event_owner: data[:event_owner],
       local_event: data[:address], limit_participants: data[:participants_limit],  url_event: data[:url_event], schedules: data[:schedules] || [],
-      description: data[:description], start_date: data[:start_date].to_date, end_date: data[:end_date].to_date, batches: data[:ticket_batches] || []
+      description: data[:description], start_date: data[:start_date].to_date, end_date: data[:end_date].to_date, batches: data[:ticket_batches] || [],
+      announcements: data[:announcements] || []
     )
   end
 
@@ -81,5 +83,9 @@ class Event
     batches.map { |data| Batch.new(batch_id: data[:code], name: data[:name], limit_tickets: data[:tickets_limit],
               start_date: data[:start_date].to_date, value: data[:ticket_price], end_date: data[:end_date].to_date,
               event_id: event_id) }
+  end
+
+  def build_announcement(announcements)
+    announcements.map { |data| Announcement.new(announcement_id: data[:id], title: data[:title], description: data[:description], event_id: data[:event_id]) }
   end
 end

--- a/app/views/announcements/_announcement.html.erb
+++ b/app/views/announcements/_announcement.html.erb
@@ -1,2 +1,2 @@
 <h2><%= announcement.title %><h2>
-<p><%= announcement.content %><p>
+<p><%= announcement.description %><p>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -99,7 +99,9 @@
         </div>
         <ul class="space-y-4">
           <% if @announcements.any? %>
-            <%= render @announcements %>
+            <% @announcements.each do |announcement| %>
+              <%= render 'announcements/announcement', announcement: announcement %>
+            <% end %>
           <% end %>
         </ul>
         <ul class="space-y-4">

--- a/db/migrate/20250204211415_drop_table_announcements.rb
+++ b/db/migrate/20250204211415_drop_table_announcements.rb
@@ -1,0 +1,5 @@
+class DropTableAnnouncements < ActiveRecord::Migration[8.0]
+  def change
+    drop_table :announcements
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_04_192224) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_04_211415) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -47,14 +47,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_04_192224) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
-  end
-
-  create_table "announcements", force: :cascade do |t|
-    t.string "title", null: false
-    t.string "content", null: false
-    t.string "event_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
   end
 
   create_table "comments", force: :cascade do |t|

--- a/spec/factories/announcements.rb
+++ b/spec/factories/announcements.rb
@@ -1,7 +1,16 @@
 FactoryBot.define do
   factory :announcement do
-    title { "MyString" }
-    content { "MyString" }
-    event_id { 1 }
+    sequence(:announcement_id)
+    title { "Dev Week" }
+    description { 'Aprenda em a ganhar 10 mil dólares em um mês' }
+    event_id { "hjkds" }
+    initialize_with do
+      new(
+        announcement_id: announcement_id,
+        event_id: event_id,
+        title: title,
+        description: description,
+      )
+    end
   end
 end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -13,6 +13,7 @@ FactoryBot.define do
     event_owner { 'Samuel' }
     batches { [] }
     schedules { [] }
+    announcements { [] }
 
     initialize_with do
       new(
@@ -28,7 +29,8 @@ FactoryBot.define do
         description: description,
         event_owner: event_owner,
         batches: batches,
-        schedules: schedules
+        schedules: schedules,
+        announcements: announcements
       )
     end
   end

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -1,9 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe Announcement, type: :model do
-  context 'validations' do
-    it { should validate_presence_of(:event_id) }
-    it { should validate_presence_of(:content) }
-    it { should validate_presence_of(:title) }
-  end
-end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe Event, type: :model do
         event_owner:	'Samuel',
         start_date:	"2025-02-01T12:00:00.000-03:00",
         end_date:	"2025-02-04T12:00:00.000-03:00",
-        announcements: []
       }
 
       response = double('response', status: 200, body: event.to_json)
@@ -106,6 +105,45 @@ RSpec.describe Event, type: :model do
 
       expect(result.schedules[2].date).to eq "Fri, 16 Feb 2025".to_datetime
       expect(result.schedules[2].schedule_items).to eq []
+    end
+
+    it "e retorna detalhes do evento com announcements" do
+      event = {
+        code:	"1",
+        name:	'Aprendedo a cozinhar',
+        description:	'Aprenda a fritar um ovo',
+        address:	'Rua dos morcegos, 137, CEP: 40000000, Salvador, Bahia, Brasil',
+        banner_url:	'https://via.placeholder.com/300x200',
+        logo_url: 'https://via.placeholder.com/100x100',
+        participants_limit:	30,
+        event_owner:	'Samuel',
+        start_date:	"2025-02-01T12:00:00.000-03:00",
+        end_date:	"2025-02-04T12:00:00.000-03:00",
+        announcements: [ {
+          id: 1,
+          title: "Quem quer dinheiro",
+          description: 'Todos nós'
+        },
+        {
+          id: 2,
+          title: "Taxa adicional",
+          description: 'R$ 100,00'
+        }
+      ]
+      }
+      response = double('response', status: 200, body: event.to_json)
+      allow_any_instance_of(Faraday::Connection).to receive(:get).with('http://localhost:3000/api/v1/events/1').and_return(response)
+      result = Event.request_event_by_id(event[:code])
+
+      expect(result.announcements[0].announcement_id).to eq 1
+      expect(result.announcements[0].title).to eq 'Quem quer dinheiro'
+      expect(result.announcements[0].description).to eq 'Todos nós'
+
+      expect(result.announcements[1].announcement_id).to eq 2
+      expect(result.announcements[1].title).to eq 'Taxa adicional'
+      expect(result.announcements[1].description).to eq 'R$ 100,00'
+
+      expect(result.announcements.length).to eq 2
     end
 
     it "e retorna um array vazio, caso a API retorne status 500" do

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe Event, type: :model do
         participants_limit:	30,
         event_owner:	'Samuel',
         start_date:	"2025-02-01T12:00:00.000-03:00",
-        end_date:	"2025-02-04T12:00:00.000-03:00"
+        end_date:	"2025-02-04T12:00:00.000-03:00",
+        announcements: []
       }
 
       response = double('response', status: 200, body: event.to_json)
@@ -80,7 +81,8 @@ RSpec.describe Event, type: :model do
         event_owner:	'Samuel',
         start_date:	"2025-02-01T12:00:00.000-03:00",
         end_date:	"2025-02-04T12:00:00.000-03:00",
-        schedules: schedules
+        schedules: schedules,
+        announcements: []
       }
       response = double('response', status: 200, body: event.to_json)
       allow_any_instance_of(Faraday::Connection).to receive(:get).with('http://localhost:3000/api/v1/events/1').and_return(response)

--- a/spec/support/json/error_events_list.json
+++ b/spec/support/json/error_events_list.json
@@ -12,7 +12,8 @@
       "description": "Aprenda a fritar um ovo",
       "event_owner": "Samuel",
       "participants_limit": 30,
-      "url_event": "http: //evento_fake.com"
+      "url_event": "http: //evento_fake.com",
+      "announcements": []
     },
     {
       "code": "2",
@@ -25,7 +26,8 @@
       "description": "Aprenda a fritar um ovo",
       "event_owner": "Samuel",
       "participants_limit": 30,
-      "url_event": "http: //evento_fake.com"
+      "url_event": "http: //evento_fake.com",
+      "announcements": []
       },
 
     { 
@@ -39,7 +41,8 @@
       "description": "Aprenda a fritar um ovo",
       "event_owner": "Samuel",
       "participants_limit": 30,
-      "url_event": "http: //evento_fake.com"
+      "url_event": "http: //evento_fake.com",
+      "announcements": []
     }
   ]
 }

--- a/spec/support/json/events_list.json
+++ b/spec/support/json/events_list.json
@@ -11,7 +11,8 @@
       "description": "Aprenda a fritar um ovo",
       "event_owner": "Samuel",
       "participants_limit": 30,
-      "url_event": "http: //evento_fake.com"
+      "url_event": "http: //evento_fake.com",
+      "announcements": []
     },
     {
       "code": "2",
@@ -24,7 +25,8 @@
       "description": "Aprenda a fritar um ovo",
       "event_owner": "Samuel",
       "participants_limit": 30,
-      "url_event": "http: //evento_fake.com"
+      "url_event": "http: //evento_fake.com",
+      "announcements": []
     }
   ]
 }

--- a/spec/system/annoucement/user_view_annoucements_spec.rb
+++ b/spec/system/annoucement/user_view_annoucements_spec.rb
@@ -2,10 +2,11 @@ require 'rails_helper'
 
 describe 'Usuário acessa feed do evento e vê comunicados oficiais' do
   it 'com sucesso' do
-    event = build(:event, name: 'DevWeek')
+    announcement = build(:announcement, title: 'Taxa extra de R$100,00', content: 'NOVA TAXA: PAGUEM!')
+
+    event = build(:event, name: 'DevWeek', announcements: [ announcement ])
     ticket = create(:ticket, event_id: event.event_id)
     user = ticket.user
-    create(:announcement, title: 'Taxa extra de R$100,00', event_id: event.event_id, content: 'NOVA TAXA: PAGUEM!')
     allow(Event).to receive(:all).and_return([ event ])
     allow(Event).to receive(:request_event_by_id).and_return(event)
 

--- a/spec/system/annoucement/user_view_annoucements_spec.rb
+++ b/spec/system/annoucement/user_view_annoucements_spec.rb
@@ -2,9 +2,11 @@ require 'rails_helper'
 
 describe 'Usuário acessa feed do evento e vê comunicados oficiais' do
   it 'com sucesso' do
-    announcement = build(:announcement, title: 'Taxa extra de R$100,00', content: 'NOVA TAXA: PAGUEM!')
+    announcement = build(:announcement, title: 'Taxa extra de R$100,00', description: 'NOVA TAXA: PAGUEM!')
 
-    event = build(:event, name: 'DevWeek', announcements: [ announcement ])
+    event = build(:event, name: 'DevWeek')
+    p event
+    event.announcements << announcement
     ticket = create(:ticket, event_id: event.event_id)
     user = ticket.user
     allow(Event).to receive(:all).and_return([ event ])


### PR DESCRIPTION
Cancela migração de announcement e puxa dados de api e atualiza testes unitários da event APi 
![Captura de tela de 2025-02-04 17-14-11](https://github.com/user-attachments/assets/c3c4108a-6e7f-4ff6-84dc-6a6181c85ff2)
Resolve #138 