### PR TITLE
Resolve bug que não mostrava texto enriquecido na descricão dos eventos

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -16,6 +16,10 @@ class Event
     @batches = build_batch(batches)
   end
 
+  def rich_text_description
+    ActionText::Content.new(@description)
+  end
+
   def self.all
     response = EventsApiService.get_events
     events = response[:events]

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -64,7 +64,9 @@
   </div>
   <div class="bg-white p-6 m-3 w-full">
     <h2><%= t('.event_description') %>:</h2>
-    <p class="text-sm text-gray-500 mt-1"><%= @event.description %></p>
+    <%= render 'layouts/action_text/contents/content' do %>
+      <%= @event.rich_text_description %>
+    <% end %>
   </div>          
   <div class="bg-white p-6 m-3 w-full">
     <h2><%= t('.event_agenda') %></h2>


### PR DESCRIPTION
![Captura de tela de 2025-02-05 09-15-39](https://github.com/user-attachments/assets/3279e738-1b85-495f-8287-7b10595468a1)
![Captura de tela de 2025-02-05 09-34-33](https://github.com/user-attachments/assets/d78022fa-4d1e-467d-b09e-0a29d7679b62)


Resolve #146 
