### PR TITLE
Resolve bug que não mostrava texto enriquecido na descricão 

### DIFF
--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -7,4 +7,8 @@ class Announcement
     @description = description
     @announcement_id = announcement_id
   end
+
+  def rich_text_description
+    ActionText::Content.new(@description)
+  end
 end

--- a/app/views/announcements/_announcement.html.erb
+++ b/app/views/announcements/_announcement.html.erb
@@ -1,2 +1,4 @@
 <h2><%= announcement.title %><h2>
-<p><%= announcement.description %><p>
+<%= render 'layouts/action_text/contents/content' do %>
+  <%= announcement.rich_text_description %>
+<% end %>


### PR DESCRIPTION
Resolve bug que não mostrava texto enriquecido na descricão dos comunicados oficiais
![Captura de tela de 2025-02-05 10-18-31](https://github.com/user-attachments/assets/d1c4a6c1-4977-4585-b125-1956e992dbf0)
![Captura de tela de 2025-02-05 10-27-08](https://github.com/user-attachments/assets/47bdb184-40bd-494e-8c69-c7ca5f895da3)


Resolve #148 