### PR TITLE
Adicionado feedbacks de item de um evento a endpoint de feedback

### DIFF
--- a/app/controllers/api/v1/feedbacks_controller.rb
+++ b/app/controllers/api/v1/feedbacks_controller.rb
@@ -2,12 +2,19 @@ class Api::V1::FeedbacksController < Api::V1::ApiController
   before_action :set_and_check_event
 
   def index
+    @item_feedbacks = ItemFeedback.where(event_id: @event.event_id)
     @feedbacks = Feedback.where(event_id: @event.event_id)
-    if @feedbacks.any?
+    if @feedbacks.any? || @item_feedbacks.any?
+      item_feedbacks = @item_feedbacks.map { |item_feedback| { id: item_feedback.id, title: item_feedback.title,
+                                                               comment: item_feedback.comment, mark: item_feedback.mark,
+                                                               user: item_feedback.user.full_name,
+                                                               schedule_item_id: item_feedback.schedule_item_id } }
+
       feedback_json = @feedbacks.map { |feedback| { id: feedback.id, title: feedback.title,
                                                     comment: feedback.comment, mark: feedback.mark,
                                                     user: feedback.user.full_name } }
-      render status: :ok, json: { event_id: @event.event_id, feedbacks: feedback_json }
+
+      render status: :ok, json: { event_id: @event.event_id, feedbacks: feedback_json, item_feedbacks: item_feedbacks }
     else
       render status: :not_found, json: { event_id: @event.event_id, error: "There is no feedbacks to this event yet" }
     end

--- a/spec/factories/item_feedbacks.rb
+++ b/spec/factories/item_feedbacks.rb
@@ -1,12 +1,10 @@
 FactoryBot.define do
   factory :item_feedback do
-    title { "MyString" }
-    comment { "MyString" }
-    answer { "MyString" }
+    event_id { "1" }
+    user
+    title { "Título Padrão" }
+    comment { "Comentário Padrão" }
     mark { 1 }
-    public { false }
-    event_id { "MyString" }
-    user { nil }
-    schedule_item_id { "MyString" }
+    schedule_item_id { "1" }
   end
 end

--- a/spec/requests/apis/feedbacks/feedbacks_api_spec.rb
+++ b/spec/requests/apis/feedbacks/feedbacks_api_spec.rb
@@ -3,6 +3,68 @@ require 'rails_helper'
 describe 'Feedback API' do
   context 'Retorna os feedback de um evento' do
     it 'com sucesso' do
+      schedules = [
+        {
+          date: 	5.day.ago,
+          schedule_items: [
+            {
+              name:	"Palestra",
+              start_time:	5.day.ago.beginning_of_day + 9.hours,
+              end_time:	5.day.ago.beginning_of_day + 10.hours,
+              code: '1'
+            },
+            {
+              name:	"Workshop",
+              start_time:	5.day.ago.beginning_of_day + 12.hours,
+              end_time:	5.day.ago.beginning_of_day + 13.hours,
+              code: '2'
+            }
+          ]
+        }
+      ]
+      user = create(:user, name: 'Gabriel', last_name: 'Tavares')
+      other_user = create(:user, name: 'David', last_name: 'Martinez')
+      event = build(:event, event_id: '1', start_date: 5.days.ago, end_date: 5.days.from_now, name: 'DevWeek', schedules: schedules)
+      schedule_item = event.schedules[0].schedule_items[0]
+      create(:ticket, event_id: event.event_id, user: user)
+      create(:ticket, event_id: event.event_id, user: other_user)
+      allow(Event).to receive(:request_event_by_id).and_return(event)
+      travel_to 6.days.from_now do
+        login_as user
+        create(:feedback, title: 'Título', comment: 'Comentário', mark: 4, event_id: event.event_id,
+               user: user, public: false)
+        login_as other_user
+        create(:feedback, title: 'Título Padrão', comment: 'Comentário Padrão', mark: 3, event_id: event.event_id,
+               user: other_user, public: true)
+        create(:item_feedback, title: 'Título do feedback de item', comment: 'Comentário Padrão de item', mark: 4, event_id: event.event_id,
+               user: other_user, schedule_item_id: schedule_item.schedule_item_id, public: true)
+
+        get "/api/v1/events/#{event.event_id}/feedbacks"
+
+        expect(response.status).to eq 200
+        expect(response.content_type).to include 'application/json'
+        json_response = JSON.parse(response.body)
+        expect(json_response["event_id"]).to eq '1'
+        expect(json_response["feedbacks"][0]["id"]).to eq 1
+        expect(json_response["feedbacks"][0]["title"]).to eq 'Título'
+        expect(json_response["feedbacks"][0]["comment"]).to eq 'Comentário'
+        expect(json_response["feedbacks"][0]["mark"]).to eq 4
+        expect(json_response["feedbacks"][0]["user"]).to eq 'Gabriel Tavares'
+        expect(json_response["feedbacks"][1]["id"]).to eq 2
+        expect(json_response["feedbacks"][1]["title"]).to eq 'Título Padrão'
+        expect(json_response["feedbacks"][1]["comment"]).to eq 'Comentário Padrão'
+        expect(json_response["feedbacks"][1]["mark"]).to eq 3
+        expect(json_response["feedbacks"][1]["user"]).to eq 'David Martinez'
+        expect(json_response["item_feedbacks"][0]["id"]).to eq 1
+        expect(json_response["item_feedbacks"][0]["schedule_item_id"]).to eq '1'
+        expect(json_response["item_feedbacks"][0]["title"]).to eq 'Título do feedback de item'
+        expect(json_response["item_feedbacks"][0]["comment"]).to eq 'Comentário Padrão de item'
+        expect(json_response["item_feedbacks"][0]["mark"]).to eq 4
+        expect(json_response["item_feedbacks"][0]["user"]).to eq 'David Martinez'
+      end
+    end
+
+    it 'e mostra feedback do evento quando não existe feedback do item' do
       user = create(:user, name: 'Gabriel', last_name: 'Tavares')
       other_user = create(:user, name: 'David', last_name: 'Martinez')
       event = build(:event, event_id: '1', start_date: 5.days.ago, end_date: 5.days.from_now, name: 'DevWeek')
@@ -33,6 +95,53 @@ describe 'Feedback API' do
         expect(json_response["feedbacks"][1]["comment"]).to eq 'Comentário Padrão'
         expect(json_response["feedbacks"][1]["mark"]).to eq 3
         expect(json_response["feedbacks"][1]["user"]).to eq 'David Martinez'
+        expect(json_response["item_feedbacks"]).to be_empty
+      end
+    end
+
+    it 'e mostra feedback do item quando não existe feedback do evento' do
+      schedules = [
+        {
+          date: 	5.day.ago,
+          schedule_items: [
+            {
+              name:	"Palestra",
+              start_time:	5.day.ago.beginning_of_day + 9.hours,
+              end_time:	5.day.ago.beginning_of_day + 10.hours,
+              code: '1'
+            },
+            {
+              name:	"Workshop",
+              start_time:	5.day.ago.beginning_of_day + 12.hours,
+              end_time:	5.day.ago.beginning_of_day + 13.hours,
+              code: '2'
+            }
+          ]
+        }
+      ]
+      user = create(:user, name: 'Gabriel', last_name: 'Tavares')
+      event = build(:event, event_id: '1', start_date: 5.days.ago, end_date: 5.days.from_now, name: 'DevWeek', schedules: schedules)
+      schedule_item = event.schedules[0].schedule_items[0]
+      create(:ticket, event_id: event.event_id, user: user)
+      allow(Event).to receive(:request_event_by_id).and_return(event)
+      travel_to 6.days.from_now do
+        login_as user
+        create(:item_feedback, title: 'Título do feedback de item', comment: 'Comentário Padrão de item', mark: 4, event_id: event.event_id,
+               user: user, schedule_item_id: schedule_item.schedule_item_id, public: true)
+
+        get "/api/v1/events/#{event.event_id}/feedbacks"
+
+        expect(response.status).to eq 200
+        expect(response.content_type).to include 'application/json'
+        json_response = JSON.parse(response.body)
+        expect(json_response["event_id"]).to eq '1'
+        expect(json_response["feedbacks"]).to be_empty
+        expect(json_response["item_feedbacks"][0]["id"]).to eq 1
+        expect(json_response["item_feedbacks"][0]["schedule_item_id"]).to eq '1'
+        expect(json_response["item_feedbacks"][0]["title"]).to eq 'Título do feedback de item'
+        expect(json_response["item_feedbacks"][0]["comment"]).to eq 'Comentário Padrão de item'
+        expect(json_response["item_feedbacks"][0]["mark"]).to eq 4
+        expect(json_response["item_feedbacks"][0]["user"]).to eq 'Gabriel Tavares'
       end
     end
 


### PR DESCRIPTION
Refatoração de teste  e controller para mostrar os items do evento no endpoint de feedback 

endpoint:
![Captura de tela de 2025-02-06 15-26-06](https://github.com/user-attachments/assets/924d469a-74a4-4df2-86ee-93b6be53d121)

Resolve #162 
