### PR TITLE
Adiciona campos de schedule_item oriundos da api

### DIFF
--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -9,6 +9,6 @@ class Schedule
 
   def build_schedule_items(schedule_items)
     schedule_items.map { |schedule_item| ScheduleItem.new(schedule_item_id: schedule_item[:code], name: schedule_item[:name], start_time: schedule_item[:start_time],
-                                                   end_time: schedule_item[:end_time])}
+                                                   end_time: schedule_item[:end_time], description: schedule_item[:description], responsible_name: schedule_item[:responsible_name], responsible_email: schedule_item[:responsible_email], schedule_type: schedule_item[:schedule_type])}
   end
 end

--- a/app/models/schedule_item.rb
+++ b/app/models/schedule_item.rb
@@ -1,12 +1,16 @@
 class ScheduleItem
-  attr_accessor :name, :start_time, :end_time, :schedule_item_id
-  def initialize(name:, start_time:, end_time:, schedule_item_id:)
+  attr_accessor :name, :start_time, :end_time, :schedule_item_id, :description, :responsible_name, :responsible_email, :schedule_type
+  def initialize(name:, start_time:, end_time:, schedule_item_id:, description:, responsible_name:, responsible_email:, schedule_type:)
     @name = name
     @start_time = start_time.to_datetime.strftime("%H:%M")
     @end_time = end_time.to_datetime.strftime("%H:%M")
     @schedule_item_id = schedule_item_id
     @start_time_raw = start_time.to_datetime
     @end_time_raw = end_time.to_datetime
+    @description = description
+    @responsible_email = responsible_email
+    @responsible_name = responsible_name
+    @schedule_type = schedule_type
   end
 
   def duration

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -92,6 +92,9 @@
                 <p class="font-bold text-gray-800"><%= item.name %></p>
                 <p class="text-sm text-gray-600"><span class="font-bold"><%= I18n.t('schedule.start_time') %>:</span> <%= item.start_time %></p>
                 <p class="text-sm text-gray-600"><span class="font-bold"><%= I18n.t('schedule.duration') %>:</span> <%= item.duration %>min</p>
+                 <p class="text-sm text-gray-600"><span class="font-bold"><%= I18n.t('schedule.responsible_email') %>:</span> <%= item.responsible_email %></p>
+                <p class="text-sm text-gray-600"><span class="font-bold"><%= I18n.t('schedule.responsible_name') %>:</span> <%= item.responsible_name %></p>
+                <p class="text-sm text-gray-600"><span class="font-bold"><%= I18n.t('schedule.schedule_type') %>:</span> <%=  I18n.t("schedule.schedule_types.#{item.schedule_type}") %></p>
               </div>
             <% end %>
           <% end %>

--- a/config/locales/custom/schedule/en.yml
+++ b/config/locales/custom/schedule/en.yml
@@ -5,3 +5,9 @@ en:
     type: Type of Event
     instructor: Instructor
     email: Contact
+    schedule_type: Schedule type
+    responsible_email: Email
+    responsible_name: Responsible
+    schedule_types:
+      activity: activity
+      interval: interval

--- a/config/locales/custom/schedule/pt-BR.yml
+++ b/config/locales/custom/schedule/pt-BR.yml
@@ -5,3 +5,9 @@ pt-BR:
     type: Tipo do Evento
     instructor: Instrutor
     email: Contato
+    schedule_type: Tipo
+    responsible_email: Email
+    responsible_name: Responsável
+    schedule_types:
+      activity: atividade
+      interval: intervalo

--- a/spec/factories/schedule_item.rb
+++ b/spec/factories/schedule_item.rb
@@ -4,5 +4,22 @@ FactoryBot.define do
     start_time { 2.days.from_now }
     end_time { 5.days.from_now }
     code { "ABCD1423" }
+    description { 'novo teste pra  passar' }
+    schedule_type { 'activity' }
+    responsible_name { 'Sílvio Santos' }
+    responsible_email { 'silvio@sbt.com' }
+
+    initialize_with do
+      new(
+        name: name,
+        start_time: start_time,
+        end_time: end_time,
+        code: code,
+        description: description,
+        schedule_type: schedule_type,
+        responsible_name: responsible_name,
+        responsible_email: responsible_email
+      )
+    end
   end
 end

--- a/spec/services/events_api_service_spec.rb
+++ b/spec/services/events_api_service_spec.rb
@@ -122,9 +122,22 @@ describe EventsApiService, type: :model do
         logo_url: 'https://via.placeholder.com/100x100',
         participants_limit:	30,
         event_owner:	'Samuel',
-        schedule: {
-          start_date:	"2025-02-01T12:00:00.000-03:00",
-          end_date:	"2025-02-04T12:00:00.000-03:00"
+        start_date:	"2025-02-01T12:00:00.000-03:00",
+        end_date:	"2025-02-04T12:00:00.000-03:00",
+        schedules: {
+          date: "2025-02-01",
+          schedule_items: [
+            {
+              code: 'AAAAA',
+              name: 'PROVA',
+              description: 'VALENDO 10',
+              start_time: '2025-02-02T12:00:00.000-03:00',
+              end_time: '2025-02-02T12:00:00.000-03:00',
+              responsible_name: 'Palestrante',
+              responsible_email:  'palestrante@email',
+              schedule_type: 'activity'
+            }
+          ]
         }
       }
 
@@ -139,8 +152,15 @@ describe EventsApiService, type: :model do
       expect(result[:logo_url]).to eq 'https://via.placeholder.com/100x100'
       expect(result[:description]).to eq 'Aprenda a fritar um ovo'
       expect(result[:event_owner]).to eq 'Samuel'
-      expect(result[:schedule][:start_date]).to eq "2025-02-01T12:00:00.000-03:00"
-      expect(result[:schedule][:end_date]).to eq "2025-02-04T12:00:00.000-03:00"
+      expect(result[:schedules][:date]).to eq "2025-02-01"
+      expect(result[:schedules][:schedule_items][0][:code]).to eq "AAAAA"
+      expect(result[:schedules][:schedule_items][0][:name]).to eq "PROVA"
+      expect(result[:schedules][:schedule_items][0][:description]).to eq "VALENDO 10"
+      expect(result[:schedules][:schedule_items][0][:start_time]).to eq "2025-02-02T12:00:00.000-03:00"
+      expect(result[:schedules][:schedule_items][0][:end_time]).to eq "2025-02-02T12:00:00.000-03:00"
+      expect(result[:schedules][:schedule_items][0][:responsible_name]).to eq "Palestrante"
+      expect(result[:schedules][:schedule_items][0][:responsible_email]).to eq "palestrante@email"
+      expect(result[:schedules][:schedule_items][0][:schedule_type]).to eq "activity"
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@
 #
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 require 'webmock/rspec'
-WebMock.disable_net_connect!(allow_localhost: true)
+
 RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate

--- a/spec/system/events/user_sees_events_details_spec.rb
+++ b/spec/system/events/user_sees_events_details_spec.rb
@@ -48,19 +48,19 @@ describe 'Usuário acessa página de detalhes de um evento' do
 
   it 'e consegue ver os detalhes da agenda do evento' do
     user = create(:user)
-    schedules = [
+     schedules = [
       {
         date: 	"2025-02-14",
         schedule_items: [
           {
             name:	"Palestra",
             start_time:	"2025-02-14T09:00:00.000-03:00",
-            end_time:	"2025-02-14T10:00:00.000-03:00"
-          },
-          {
-            name:	"Segunda Palestra",
-            start_time:	"2025-02-14T10:00:00.000-03:00",
-            end_time:	"2025-02-14T11:00:00.000-03:00"
+            end_time:	"2025-02-14T10:00:00.000-03:00",
+            code: "ABCD1423",
+            description: 'novo teste pra  passar',
+            schedule_type: 'activity',
+            responsible_name: 'Sílvio Santos',
+            responsible_email: 'silvio@sbt.com'
           }
         ]
       },
@@ -70,7 +70,12 @@ describe 'Usuário acessa página de detalhes de um evento' do
           {
             name:	"Apresentação",
             start_time:	"2025-02-15T09:00:00.000-03:00",
-            end_time:	"2025-02-15T10:00:00.000-03:00"
+            end_time:	"2025-02-15T10:00:00.000-03:00",
+            code: "ABCD1424",
+            description: 'apresentação de slides',
+            schedule_type: 'activity',
+            responsible_name: 'Hebe Soares',
+            responsible_email: 'soareshebe@sbt.com'
           }
         ]
       },
@@ -93,13 +98,18 @@ describe 'Usuário acessa página de detalhes de um evento' do
     expect(page).to have_content "Palestra"
     expect(page).to have_content "Início: 09:00"
     expect(page).to have_content "Duração: 60min"
-    expect(page).to have_content "Segunda Palestra"
-    expect(page).to have_content "Início: 10:00"
-    expect(page).to have_content "Duração: 60min"
+    expect(page).to have_content "Tipo: atividade"
+    expect(page).to have_content "Responsável: Sílvio Santos"
+    expect(page).to have_content "Email: silvio@sbt.com"
+
     expect(page).to have_content "15/02/2025"
     expect(page).to have_content "Apresentação"
     expect(page).to have_content "Início: 09:00"
     expect(page).to have_content "Duração: 60min"
+    expect(page).to have_content "Tipo: atividade"
+    expect(page).to have_content "Responsável: Hebe Soares"
+    expect(page).to have_content "Email: soareshebe@sbt.com"
+
     expect(page).to have_content "16/02/2025"
     expect(page).to have_content 'Ainda não existe programação cadastrada para esse dia'
   end

--- a/spec/system/events/visitant_sees_events_details_spec.rb
+++ b/spec/system/events/visitant_sees_events_details_spec.rb
@@ -49,12 +49,12 @@ describe 'Visitante acessa página de detalhes de um evento' do
           {
             name:	"Palestra",
             start_time:	"2025-02-14T09:00:00.000-03:00",
-            end_time:	"2025-02-14T10:00:00.000-03:00"
-          },
-          {
-            name:	"Segunda Palestra",
-            start_time:	"2025-02-14T10:00:00.000-03:00",
-            end_time:	"2025-02-14T11:00:00.000-03:00"
+            end_time:	"2025-02-14T10:00:00.000-03:00",
+            code: "ABCD1423",
+            description: 'novo teste pra  passar',
+            schedule_type: 'activity',
+            responsible_name: 'Sílvio Santos',
+            responsible_email: 'silvio@sbt.com'
           }
         ]
       },
@@ -64,7 +64,12 @@ describe 'Visitante acessa página de detalhes de um evento' do
           {
             name:	"Apresentação",
             start_time:	"2025-02-15T09:00:00.000-03:00",
-            end_time:	"2025-02-15T10:00:00.000-03:00"
+            end_time:	"2025-02-15T10:00:00.000-03:00",
+            code: "ABCD1424",
+            description: 'apresentação de slides',
+            schedule_type: 'activity',
+            responsible_name: 'Hebe Soares',
+            responsible_email: 'soareshebe@sbt.com'
           }
         ]
       },
@@ -86,13 +91,18 @@ describe 'Visitante acessa página de detalhes de um evento' do
     expect(page).to have_content "Palestra"
     expect(page).to have_content "Início: 09:00"
     expect(page).to have_content "Duração: 60min"
-    expect(page).to have_content "Segunda Palestra"
-    expect(page).to have_content "Início: 10:00"
-    expect(page).to have_content "Duração: 60min"
+    expect(page).to have_content "Tipo: atividade"
+    expect(page).to have_content "Responsável: Sílvio Santos"
+    expect(page).to have_content "Email: silvio@sbt.com"
+
     expect(page).to have_content "15/02/2025"
     expect(page).to have_content "Apresentação"
     expect(page).to have_content "Início: 09:00"
     expect(page).to have_content "Duração: 60min"
+    expect(page).to have_content "Tipo: atividade"
+    expect(page).to have_content "Responsável: Hebe Soares"
+    expect(page).to have_content "Email: soareshebe@sbt.com"
+
     expect(page).to have_content "16/02/2025"
     expect(page).to have_content 'Ainda não existe programação cadastrada para esse dia'
   end

--- a/spec/system/profiles/user_edit_profile_spec.rb
+++ b/spec/system/profiles/user_edit_profile_spec.rb
@@ -1,4 +1,6 @@
 require 'rails_helper'
+WebMock.disable_net_connect!(allow_localhost: true)
+WebMock.enable!
 
 describe 'usuário edita perfil' do
   it 'pela página do perfil' do
@@ -14,6 +16,7 @@ describe 'usuário edita perfil' do
 
   it 'com sucesso', type: :system, js: true do
     user = create(:user, email: 'teste@email.com')
+    stub_request(:get, 'https://brasilapi.com.br/api/ibge/uf/v1').to_return(body: "")
 
     login_as user
     visit edit_user_profile_path(user_id: user, id: user.profile)


### PR DESCRIPTION
Adiciona dados da api no poro de schedul_item, refatora build de schedule_item do factory_bot e refatora testes e show que implementa schedule.
![Captura de tela de 2025-02-06 17-15-26](https://github.com/user-attachments/assets/a80a75c1-835e-4fd9-8e57-6c573c86e026)

Resolve #165 
