### PR TITLE
Adicionado endpoint de criação de respota de um feedback de um item de um evento

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,8 @@ gem "jbuilder"
 
 gem "rqrcode"
 
+gem "rack-cors"
+
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,6 +227,8 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.1.8)
+    rack-cors (2.0.2)
+      rack (>= 2.0.0)
     rack-session (2.1.0)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -432,6 +434,7 @@ DEPENDENCIES
   jbuilder
   propshaft
   puma (>= 5.0)
+  rack-cors
   rails (~> 8.0.1)
   rqrcode
   rspec-rails

--- a/app/controllers/api/v1/feedback_answers_controller.rb
+++ b/app/controllers/api/v1/feedback_answers_controller.rb
@@ -1,6 +1,9 @@
 class Api::V1::FeedbackAnswersController < Api::V1::ApiController
+  before_action :set_and_check_item_feedback
+
   def create
     @feedback_answers = FeedbackAnswer.new(feedback_answers_params)
+    @feedback_answers.item_feedback = @item_feedback
     if @feedback_answers.save
       render status: 201, json: @feedback_answers.as_json
     else
@@ -11,6 +14,12 @@ class Api::V1::FeedbackAnswersController < Api::V1::ApiController
   private
 
   def feedback_answers_params
-    params.require(:feedback_answers).permit(:name, :email, :comment, :item_feedback_id)
+    params.require(:feedback_answers).permit(:name, :email, :comment)
+  end
+
+  def set_and_check_item_feedback
+    @item_feedback = ItemFeedback.find(params[:item_feedback_id])
+  rescue
+    render status: 404, json: { error: "Item feedback not found" }
   end
 end

--- a/app/controllers/api/v1/feedback_answers_controller.rb
+++ b/app/controllers/api/v1/feedback_answers_controller.rb
@@ -1,0 +1,14 @@
+class Api::V1::FeedbackAnswersController < Api::V1::ApiController
+  def create
+    @feedback_answers = FeedbackAnswer.new(feedback_answers_params)
+    if @feedback_answers.save
+      render status: 201, json: @feedback_answers.as_json
+    end
+  end
+
+  private
+
+  def feedback_answers_params
+    params.require(:feedback_answers).permit(:name, :email, :comment, :item_feedback_id)
+  end
+end

--- a/app/controllers/api/v1/feedback_answers_controller.rb
+++ b/app/controllers/api/v1/feedback_answers_controller.rb
@@ -14,7 +14,7 @@ class Api::V1::FeedbackAnswersController < Api::V1::ApiController
   private
 
   def feedback_answers_params
-    params.require(:feedback_answers).permit(:name, :email, :comment)
+    params.permit(:name, :email, :comment)
   end
 
   def set_and_check_item_feedback

--- a/app/controllers/api/v1/feedback_answers_controller.rb
+++ b/app/controllers/api/v1/feedback_answers_controller.rb
@@ -3,6 +3,8 @@ class Api::V1::FeedbackAnswersController < Api::V1::ApiController
     @feedback_answers = FeedbackAnswer.new(feedback_answers_params)
     if @feedback_answers.save
       render status: 201, json: @feedback_answers.as_json
+    else
+      render status: 406, json: { errors: I18n.with_locale(:en) { @feedback_answers.errors.full_messages } }
     end
   end
 

--- a/app/models/feedback_answer.rb
+++ b/app/models/feedback_answer.rb
@@ -1,3 +1,6 @@
 class FeedbackAnswer < ApplicationRecord
   belongs_to :item_feedback
+
+  validates :name, :email, :comment, presence: true
+  validates :comment, length: { maximum: 150 }
 end

--- a/app/models/feedback_answer.rb
+++ b/app/models/feedback_answer.rb
@@ -1,0 +1,3 @@
+class FeedbackAnswer < ApplicationRecord
+  belongs_to :item_feedback
+end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,0 +1,6 @@
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins "*"
+    resource "*", headers: :any, methods: [ :get, :post, :patch, :put ]
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,9 @@ Rails.application.routes.draw do
         resources :batches,  only: [ :show ]
         resources :feedbacks,  only: [ :index ]
       end
+      resources :item_feedbacks do
+        resources :feedback_answers, only: [ :create ]
+      end
     end
   end
 end

--- a/db/migrate/20250206184046_remove_answer_from_item_feedbacks.rb
+++ b/db/migrate/20250206184046_remove_answer_from_item_feedbacks.rb
@@ -1,0 +1,5 @@
+class RemoveAnswerFromItemFeedbacks < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :item_feedbacks, :answer, :string
+  end
+end

--- a/db/migrate/20250206192041_create_feedback_answers.rb
+++ b/db/migrate/20250206192041_create_feedback_answers.rb
@@ -1,0 +1,12 @@
+class CreateFeedbackAnswers < ActiveRecord::Migration[8.0]
+  def change
+    create_table :feedback_answers do |t|
+      t.string :name
+      t.string :comment
+      t.string :email
+      t.references :item_feedback, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_05_205330) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_06_184046) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -82,7 +82,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_05_205330) do
   create_table "item_feedbacks", force: :cascade do |t|
     t.string "title", null: false
     t.string "comment", null: false
-    t.string "answer"
     t.integer "mark", default: 0, null: false
     t.boolean "public", null: false
     t.string "event_id", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_06_184046) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_06_192041) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -65,6 +65,16 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_06_184046) do
     t.datetime "updated_at", null: false
     t.string "event_id", null: false
     t.index ["user_id"], name: "index_favorites_on_user_id"
+  end
+
+  create_table "feedback_answers", force: :cascade do |t|
+    t.string "name"
+    t.string "comment"
+    t.string "email"
+    t.integer "item_feedback_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["item_feedback_id"], name: "index_feedback_answers_on_item_feedback_id"
   end
 
   create_table "feedbacks", force: :cascade do |t|
@@ -179,6 +189,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_06_184046) do
   add_foreign_key "comments", "posts"
   add_foreign_key "comments", "users"
   add_foreign_key "favorites", "users"
+  add_foreign_key "feedback_answers", "item_feedbacks"
   add_foreign_key "feedbacks", "users"
   add_foreign_key "item_feedbacks", "users"
   add_foreign_key "likes", "posts"

--- a/spec/factories/feedback_answers.rb
+++ b/spec/factories/feedback_answers.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :feedback_answer do
+    name { "MyString" }
+    comment { "MyString" }
+    email { "MyString" }
+    item_feedback { nil }
+  end
+end

--- a/spec/factories/item_feedbacks.rb
+++ b/spec/factories/item_feedbacks.rb
@@ -2,7 +2,6 @@ FactoryBot.define do
   factory :item_feedback do
     title { "MyString" }
     comment { "MyString" }
-    answer { "MyString" }
     mark { 1 }
     public { false }
     event_id { "MyString" }

--- a/spec/models/feedback_answer_spec.rb
+++ b/spec/models/feedback_answer_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe FeedbackAnswer, type: :model do
+end

--- a/spec/models/feedback_answer_spec.rb
+++ b/spec/models/feedback_answer_spec.rb
@@ -1,4 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe FeedbackAnswer, type: :model do
+  describe 'validations' do
+    context 'Nome' do
+      it { is_expected.to validate_presence_of(:name) }
+    end
+
+    context 'E-mail' do
+      it { is_expected.to validate_presence_of(:email) }
+    end
+
+    context 'Comentário' do
+      it { is_expected.to validate_presence_of(:comment) }
+      subject { FactoryBot.build(:item_feedback) }
+      it { is_expected.to validate_length_of(:comment).is_at_most(150) }
+    end
+  end
 end

--- a/spec/requests/apis/item_feedback_answers/feedback_answers_api_spec.rb
+++ b/spec/requests/apis/item_feedback_answers/feedback_answers_api_spec.rb
@@ -23,7 +23,7 @@ describe 'Feedback Answer API' do
       allow(Event).to receive(:request_event_by_id).and_return(event)
       login_as user
       item_feedback = create(:item_feedback, title: 'Título do feedback de item', comment: 'Comentário Padrão de item', mark: 4, event_id: event.event_id,
-              user: user, schedule_item_id: schedule_item.schedule_item_id, public: true)
+                                             user: user, schedule_item_id: schedule_item.schedule_item_id, public: true)
 
       post "/api/v1/item_feedbacks/#{item_feedback.id}/feedback_answers", params: {
             feedback_answers: {
@@ -40,6 +40,46 @@ describe 'Feedback Answer API' do
       expect(json_response['name']).to eq 'Nome do Participante Teste'
       expect(json_response['email']).to eq 'email@teste.com'
       expect(json_response['comment']).to eq 'Comentário Teste'
+      expect(json_response['item_feedback_id']).to eq item_feedback.id
+    end
+
+    it 'e retorna erro quando a criação não é válida' do
+      schedules = [
+        {
+          date: 	5.day.ago,
+          schedule_items: [
+            {
+              name:	"Palestra",
+              start_time:	5.day.ago.beginning_of_day + 9.hours,
+              end_time:	5.day.ago.beginning_of_day + 10.hours,
+              code: '1'
+            }
+          ]
+        }
+      ]
+      user = create(:user, name: 'Gabriel', last_name: 'Tavares')
+      event = build(:event, event_id: '1', start_date: 5.days.ago, end_date: 2.days.ago, name: 'DevWeek', schedules: schedules)
+      schedule_item = event.schedules[0].schedule_items[0]
+      create(:ticket, event_id: event.event_id, user: user)
+      allow(Event).to receive(:request_event_by_id).and_return(event)
+
+      login_as user
+      item_feedback = create(:item_feedback, title: 'Título do feedback de item', comment: 'Comentário Padrão de item', mark: 4, event_id: event.event_id,
+              user: user, schedule_item_id: schedule_item.schedule_item_id, public: true)
+
+      post "/api/v1/item_feedbacks/#{item_feedback.id}/feedback_answers", params: {
+            feedback_answers: {
+            name: '',
+            email: '',
+            comment: '',
+            item_feedback_id: nil
+          }
+        }
+
+      expect(response).to have_http_status 406
+      expect(response.content_type).to include 'application/json'
+      json_response = JSON.parse(response.body)
+      expect(json_response['errors']).to match_array [ "Name can't be blank", "Email can't be blank", "Comment can't be blank", "Item feedback must exist" ]
     end
   end
 end

--- a/spec/requests/apis/item_feedback_answers/feedback_answers_api_spec.rb
+++ b/spec/requests/apis/item_feedback_answers/feedback_answers_api_spec.rb
@@ -26,11 +26,9 @@ describe 'Feedback Answer API' do
                                              user: user, schedule_item_id: schedule_item.schedule_item_id, public: true)
 
       post "/api/v1/item_feedbacks/#{item_feedback.id}/feedback_answers", params: {
-            feedback_answers: {
             name: 'Nome do Participante Teste',
             email: 'email@teste.com',
             comment: 'Comentário Teste'
-          }
         }
 
       expect(response).to have_http_status 201
@@ -67,11 +65,9 @@ describe 'Feedback Answer API' do
               user: user, schedule_item_id: schedule_item.schedule_item_id, public: true)
 
       post "/api/v1/item_feedbacks/#{item_feedback.id}/feedback_answers", params: {
-            feedback_answers: {
             name: '',
             email: '',
             comment: ''
-          }
         }
 
       expect(response).to have_http_status 406
@@ -102,11 +98,9 @@ describe 'Feedback Answer API' do
       login_as user
 
       post "/api/v1/item_feedbacks/#{item_feedback_id}/feedback_answers", params: {
-            feedback_answers: {
             name: 'Nome do Participante Teste',
             email: 'email@teste.com',
             comment: 'Comentário Teste'
-          }
         }
 
       expect(response).to have_http_status 404
@@ -140,12 +134,10 @@ describe 'Feedback Answer API' do
       allow(FeedbackAnswer).to receive(:new).and_raise(ActiveRecord::ActiveRecordError)
 
       post "/api/v1/item_feedbacks/#{item_feedback.id}/feedback_answers", params: {
-        feedback_answers: {
         name: 'Nome do Participante Teste',
         email: 'email@teste.com',
         comment: 'Comentário Teste'
       }
-    }
 
       expect(response).to have_http_status 500
       expect(response.content_type).to include 'application/json'

--- a/spec/requests/apis/item_feedback_answers/feedback_answers_api_spec.rb
+++ b/spec/requests/apis/item_feedback_answers/feedback_answers_api_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+describe 'Feedback Answer API' do
+  context 'Posta informações da resposta do feedback de um item do evento' do
+    it 'com sucesso' do
+      schedules = [
+        {
+          date: 	5.day.ago,
+          schedule_items: [
+            {
+              name:	"Palestra",
+              start_time:	5.day.ago.beginning_of_day + 9.hours,
+              end_time:	5.day.ago.beginning_of_day + 10.hours,
+              code: '1'
+            }
+          ]
+        }
+      ]
+      user = create(:user, name: 'Gabriel', last_name: 'Tavares')
+      event = build(:event, event_id: '1', start_date: 5.days.ago, end_date: 2.days.ago, name: 'DevWeek', schedules: schedules)
+      schedule_item = event.schedules[0].schedule_items[0]
+      create(:ticket, event_id: event.event_id, user: user)
+      allow(Event).to receive(:request_event_by_id).and_return(event)
+      login_as user
+      item_feedback = create(:item_feedback, title: 'Título do feedback de item', comment: 'Comentário Padrão de item', mark: 4, event_id: event.event_id,
+              user: user, schedule_item_id: schedule_item.schedule_item_id, public: true)
+
+      post "/api/v1/item_feedbacks/#{item_feedback.id}/feedback_answers", params: {
+            feedback_answers: {
+            name: 'Nome do Participante Teste',
+            email: 'email@teste.com',
+            comment: 'Comentário Teste',
+            item_feedback_id: item_feedback.id
+          }
+        }
+
+      expect(response).to have_http_status 201
+      expect(response.content_type).to include 'application/json'
+      json_response = JSON.parse(response.body)
+      expect(json_response['name']).to eq 'Nome do Participante Teste'
+      expect(json_response['email']).to eq 'email@teste.com'
+      expect(json_response['comment']).to eq 'Comentário Teste'
+    end
+  end
+end


### PR DESCRIPTION
Cria rota e testes de criação de resposta feedback de um item de um evento
Adicionada gem rack-cors 

Requisição:
![Captura de tela de 2025-02-06 18-30-23](https://github.com/user-attachments/assets/7c1464ff-579e-487c-ab57-5cf47dc91ae3)
![Captura de tela de 2025-02-06 18-30-49](https://github.com/user-attachments/assets/ddcc88e9-23c3-4dcc-896e-f99404a77e7a)

Resolve #163 



