### PR TITLE
API para usar o ticket no dia do evento

### DIFF
--- a/app/controllers/api/v1/tickets_controller.rb
+++ b/app/controllers/api/v1/tickets_controller.rb
@@ -1,0 +1,28 @@
+class Api::V1::TicketsController < Api::V1::ApiController
+  before_action :set_ticket
+  before_action :check_event
+
+  def used
+    unless @ticket.used?
+      @ticket.used!
+      render status: 200, json: @ticket.as_json(except: [ :id, :created_at, :updated_at ])
+    else
+      render status: 422, json: { error: "This ticket is already used for this day" }
+    end
+  end
+
+  private
+
+  def set_ticket
+    @ticket = Ticket.find_by(token: params[:token])
+  end
+
+  def check_ticket
+
+  end
+  
+  def check_event
+    event = Event.request_event_by_id(@ticket.event_id)
+    render status: 404, json: { error: "This ticket can be used only on the day of the event" } unless DateTime.now.between?(event.start_date, event.end_date)
+  end
+end

--- a/app/controllers/api/v1/tickets_controller.rb
+++ b/app/controllers/api/v1/tickets_controller.rb
@@ -1,13 +1,16 @@
 class Api::V1::TicketsController < Api::V1::ApiController
   before_action :set_ticket
-  before_action :check_event
+  before_action :check_ticket
 
   def used
-    unless @ticket.used?
+    if @ticket.usable?
       @ticket.used!
       render status: 200, json: @ticket.as_json(except: [ :id, :created_at, :updated_at ])
-    else
+      @ticket.ticket_usages.create!(date: Time.zone.now)
+    elsif @ticket.used?
       render status: 422, json: { error: "This ticket is already used for this day" }
+    elsif @ticket.not_the_date?
+      render status: 404, json: { error: "This ticket can be used only on the day of the event" } unless DateTime.now.between?(event.start_date, event.end_date)
     end
   end
 
@@ -17,12 +20,13 @@ class Api::V1::TicketsController < Api::V1::ApiController
     @ticket = Ticket.find_by(token: params[:token])
   end
 
-  def check_ticket
-
+  def ticket_used_today?
+    @ticket.ticket_usages.where(date: Time.zone.now.beginning_of_day..Time.zone.now.end_of_day).count
   end
-  
-  def check_event
-    event = Event.request_event_by_id(@ticket.event_id)
-    render status: 404, json: { error: "This ticket can be used only on the day of the event" } unless DateTime.now.between?(event.start_date, event.end_date)
+
+  def check_ticket
+    unless ticket_used_today? > 0
+      @ticket.usable!
+    end
   end
 end

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -10,6 +10,8 @@ class Ticket < ApplicationRecord
   before_validation :set_ticket_token, :set_date_of_purchase, on: :create
   before_save :mark_status_as_confirmed
 
+  enum :usage_status, not_the_date: 0, usable: 2, used: 4
+
   private
   def set_ticket_token
     self.token = SecureRandom.alphanumeric(36)

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -1,7 +1,9 @@
 class Ticket < ApplicationRecord
   belongs_to :user
+  has_many :ticket_usages
 
   enum :payment_method, paypal: 0, pix: 1, credit_card: 2, bank_slip: 3, cash: 4
+  enum :usage_status, not_the_date: 0, usable: 2, used: 4
 
   validates :batch_id, :payment_method, presence: true
   validates :token, uniqueness: true
@@ -10,9 +12,18 @@ class Ticket < ApplicationRecord
   before_validation :set_ticket_token, :set_date_of_purchase, on: :create
   before_save :mark_status_as_confirmed
 
-  enum :usage_status, not_the_date: 0, usable: 2, used: 4
+  def used!
+    return errors.add(:usage_status, "não pode ser usado um ticket não usável") unless usable?
+    super
+  end
+
+  def usable!
+    return errors.add(:usage_status, "não pode ser usável quando não é a data do evento") unless check_event
+    super
+  end
 
   private
+
   def set_ticket_token
     self.token = SecureRandom.alphanumeric(36)
   end
@@ -23,5 +34,10 @@ class Ticket < ApplicationRecord
 
   def mark_status_as_confirmed
     self.status_confirmed = true
+  end
+
+  def check_event
+    event = Event.request_event_by_id(event_id)
+    DateTime.now.between?(event.start_date, event.end_date)
   end
 end

--- a/app/models/ticket_usage.rb
+++ b/app/models/ticket_usage.rb
@@ -1,0 +1,3 @@
+class TicketUsage < ApplicationRecord
+  belongs_to :ticket
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,9 @@ Rails.application.routes.draw do
       resources :item_feedbacks do
         resources :feedback_answers, only: [ :create ]
       end
+      resources :tickets, param: :token do
+        post "used", on: :member
+      end
     end
   end
 end

--- a/db/migrate/20250207135643_add_usage_status_to_tickets.rb
+++ b/db/migrate/20250207135643_add_usage_status_to_tickets.rb
@@ -1,0 +1,5 @@
+class AddUsageStatusToTickets < ActiveRecord::Migration[8.0]
+  def change
+    add_column :tickets, :usage_status, :integer, default: 0
+  end
+end

--- a/db/migrate/20250207144207_create_ticket_usages.rb
+++ b/db/migrate/20250207144207_create_ticket_usages.rb
@@ -1,0 +1,10 @@
+class CreateTicketUsages < ActiveRecord::Migration[8.0]
+  def change
+    create_table :ticket_usages do |t|
+      t.references :ticket, null: false, foreign_key: true
+      t.datetime :date
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_07_135643) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_07_144207) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -156,6 +156,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_07_135643) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "ticket_usages", force: :cascade do |t|
+    t.integer "ticket_id", null: false
+    t.datetime "date"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["ticket_id"], name: "index_ticket_usages_on_ticket_id"
+  end
+
   create_table "tickets", force: :cascade do |t|
     t.boolean "status_confirmed", default: false
     t.datetime "date_of_purchase"
@@ -200,5 +208,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_07_135643) do
   add_foreign_key "reminders", "users"
   add_foreign_key "social_links", "profiles"
   add_foreign_key "social_links", "social_media"
+  add_foreign_key "ticket_usages", "tickets"
   add_foreign_key "tickets", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_06_192041) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_07_135643) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -166,6 +166,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_06_192041) do
     t.datetime "updated_at", null: false
     t.string "event_id", null: false
     t.string "batch_id"
+    t.integer "usage_status", default: 0
     t.index ["user_id"], name: "index_tickets_on_user_id"
   end
 

--- a/spec/factories/ticket_usages.rb
+++ b/spec/factories/ticket_usages.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :ticket_usage do
+    ticket { nil }
+    date { "2025-02-07 11:42:07" }
+  end
+end

--- a/spec/models/ticket_spec.rb
+++ b/spec/models/ticket_spec.rb
@@ -99,5 +99,79 @@ RSpec.describe Ticket, type: :model do
       )
       expect(ticket.status_confirmed?).to eq true
     end
+
+    context 'e pode ser marcado como usado' do
+      it 'com sucesso' do
+        user = create(:user)
+        event = build(:event, event_id: '1', start_date: 2.days.ago, end_date: 2.days.from_now)
+        batch = build(:batch, batch_id: '1', name: "Meia-Entrada")
+        allow(Event).to receive(:request_event_by_id).and_return(event)
+
+        ticket = Ticket.create(
+          user: user,
+          batch_id: batch.batch_id,
+          event_id: event.event_id,
+          payment_method: 'pix',
+        )
+        ticket.usable!
+        ticket.used!
+
+        expect(ticket.used?).to eq true
+      end
+
+      it 'só quando ele é usable' do
+        user = create(:user)
+        event = build(:event, event_id: '1', start_date: 2.days.ago, end_date: 2.days.from_now)
+        batch = build(:batch, batch_id: '1', name: "Meia-Entrada")
+        allow(Event).to receive(:request_event_by_id).and_return(event)
+
+        ticket = Ticket.create(
+          user: user,
+          batch_id: batch.batch_id,
+          event_id: event.event_id,
+          payment_method: 'pix',
+        )
+        ticket.not_the_date!
+        ticket.used!
+
+        expect(ticket.used?).to eq false
+      end
+    end
+
+    context 'e pode ser marcado como usável' do
+      it 'com sucesso' do
+        user = create(:user)
+        event = build(:event, event_id: '1', start_date: 2.days.ago, end_date: 2.days.from_now)
+        batch = build(:batch, batch_id: '1', name: "Meia-Entrada")
+        allow(Event).to receive(:request_event_by_id).and_return(event)
+
+        ticket = Ticket.create(
+          user: user,
+          batch_id: batch.batch_id,
+          event_id: event.event_id,
+          payment_method: 'pix',
+        )
+        ticket.usable!
+
+        expect(ticket.usable?).to eq true
+      end
+
+      it 'só quando é o dia do evento' do
+        user = create(:user)
+        event = build(:event, event_id: '1', start_date: 2.days.from_now, end_date: 5.days.from_now)
+        batch = build(:batch, batch_id: '1', name: "Meia-Entrada")
+        allow(Event).to receive(:request_event_by_id).and_return(event)
+
+        ticket = Ticket.create(
+          user: user,
+          batch_id: batch.batch_id,
+          event_id: event.event_id,
+          payment_method: 'pix',
+        )
+        ticket.usable!
+
+        expect(ticket.usable?).to eq false
+      end
+    end
   end
 end

--- a/spec/models/ticket_usage_spec.rb
+++ b/spec/models/ticket_usage_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe TicketUsage, type: :model do
+end

--- a/spec/requests/apis/tickets/tickets_api_spec.rb
+++ b/spec/requests/apis/tickets/tickets_api_spec.rb
@@ -130,5 +130,119 @@ describe 'Tickets API' do
 
       expect(response.status).to eq 500
     end
+
+    context 'E retorna usado ao receber o token do ticket' do
+      it 'com sucesso' do
+        batches = [
+          {
+          id: '1',
+          name: 'Entrada - Meia',
+          limit_tickets: 20,
+          start_date: 5.days.ago.to_date,
+          value: 20.00,
+          end_date: 2.month.from_now.to_date,
+          event_id: '1'
+          },
+          {
+          id: '2',
+          name: 'PCD - Meia',
+          limit_tickets: 50,
+          start_date: 6.days.ago.to_date,
+          value: 10.00,
+          end_date: 2.month.from_now.to_date,
+          event_id: '1'
+          }
+        ]
+        target_batch = batches[1]
+        event = build(:event, name: 'DevWeek',  event_id: '1', batches: batches,
+                              start_date: Date.today, end_date: 3.days.from_now)
+        ticket = create(:ticket, event_id: '1', batch_id: target_batch[:id])
+        allow(Event).to receive(:request_event_by_id).and_return(event)
+        allow(Batch).to receive(:get_batch_by_id).and_return(target_batch)
+
+        post "/api/v1/tickets/#{ticket.token}/used"
+
+        expect(response.status).to eq 200
+        expect(response.content_type).to include 'application/json'
+        json_response = JSON.parse(response.body)
+        expect(json_response["usage_status"]).to eq 'used'
+      end
+
+      it 'e não pode ser usado mais de duas vezes por dia' do
+        batches = [
+          {
+          id: '1',
+          name: 'Entrada - Meia',
+          limit_tickets: 20,
+          start_date: 5.days.ago.to_date,
+          value: 20.00,
+          end_date: 2.month.from_now.to_date,
+          event_id: '1'
+          },
+          {
+          id: '2',
+          name: 'PCD - Meia',
+          limit_tickets: 50,
+          start_date: 6.days.ago.to_date,
+          value: 10.00,
+          end_date: 2.month.from_now.to_date,
+          event_id: '1'
+          }
+        ]
+        target_batch = batches[1]
+        event = build(:event, name: 'DevWeek',  event_id: '1', batches: batches,
+                              start_date: Date.today, end_date: 3.days.from_now)
+        ticket = create(:ticket, event_id: '1', batch_id: target_batch[:id])
+        allow(Event).to receive(:request_event_by_id).and_return(event).exactly(2)
+        allow(Batch).to receive(:get_batch_by_id).and_return(target_batch).exactly(2)
+
+        post "/api/v1/tickets/#{ticket.token}/used"
+        post "/api/v1/tickets/#{ticket.token}/used"
+
+        expect(response.status).to eq 422
+        expect(response.content_type).to include 'application/json'
+        json_response = JSON.parse(response.body)
+        expect(json_response["error"]).to eq 'This ticket is already used for this day'
+      end
+
+      it 'e pode ser usado em dias diferente de um evento' do
+        batches = [
+          {
+          id: '1',
+          name: 'Entrada - Meia',
+          limit_tickets: 20,
+          start_date: 5.days.ago.to_date,
+          value: 20.00,
+          end_date: 2.month.from_now.to_date,
+          event_id: '1'
+          },
+          {
+          id: '2',
+          name: 'PCD - Meia',
+          limit_tickets: 50,
+          start_date: 6.days.ago.to_date,
+          value: 10.00,
+          end_date: 2.month.from_now.to_date,
+          event_id: '1'
+          }
+        ]
+        target_batch = batches[1]
+        event = build(:event, name: 'DevWeek',  event_id: '1', batches: batches,
+                              start_date: Date.today, end_date: 3.days.from_now)
+        ticket = create(:ticket, event_id: '1', batch_id: target_batch[:id])
+        allow(Event).to receive(:request_event_by_id).and_return(event).exactly(2)
+        allow(Batch).to receive(:get_batch_by_id).and_return(target_batch).exactly(2)
+
+        post "/api/v1/tickets/#{ticket.token}/used"
+        travel_to 1.day.from_now do
+          post "/api/v1/tickets/#{ticket.token}/used"
+
+          expect(response.status).to eq 200
+          expect(response.content_type).to include 'application/json'
+          json_response = JSON.parse(response.body)
+          expect(json_response["usage_status"]).to eq 'used'
+        end
+      end
+    end
   end
 end

--- a/spec/requests/apis/tickets/tickets_api_spec.rb
+++ b/spec/requests/apis/tickets/tickets_api_spec.rb
@@ -130,118 +130,117 @@ describe 'Tickets API' do
 
       expect(response.status).to eq 500
     end
+  end
+  context 'E retorna usado ao receber o token do ticket' do
+    it 'com sucesso' do
+      batches = [
+        {
+        id: '1',
+        name: 'Entrada - Meia',
+        limit_tickets: 20,
+        start_date: 5.days.ago.to_date,
+        value: 20.00,
+        end_date: 2.month.from_now.to_date,
+        event_id: '1'
+        },
+        {
+        id: '2',
+        name: 'PCD - Meia',
+        limit_tickets: 50,
+        start_date: 6.days.ago.to_date,
+        value: 10.00,
+        end_date: 2.month.from_now.to_date,
+        event_id: '1'
+        }
+      ]
+      target_batch = batches[1]
+      event = build(:event, name: 'DevWeek',  event_id: '1', batches: batches,
+                            start_date: Date.today, end_date: 3.days.from_now)
+      ticket = create(:ticket, event_id: '1', batch_id: target_batch[:id])
+      allow(Event).to receive(:request_event_by_id).and_return(event)
+      allow(Batch).to receive(:get_batch_by_id).and_return(target_batch)
 
-    context 'E retorna usado ao receber o token do ticket' do
-      it 'com sucesso' do
-        batches = [
-          {
-          id: '1',
-          name: 'Entrada - Meia',
-          limit_tickets: 20,
-          start_date: 5.days.ago.to_date,
-          value: 20.00,
-          end_date: 2.month.from_now.to_date,
-          event_id: '1'
-          },
-          {
-          id: '2',
-          name: 'PCD - Meia',
-          limit_tickets: 50,
-          start_date: 6.days.ago.to_date,
-          value: 10.00,
-          end_date: 2.month.from_now.to_date,
-          event_id: '1'
-          }
-        ]
-        target_batch = batches[1]
-        event = build(:event, name: 'DevWeek',  event_id: '1', batches: batches,
-                              start_date: Date.today, end_date: 3.days.from_now)
-        ticket = create(:ticket, event_id: '1', batch_id: target_batch[:id])
-        allow(Event).to receive(:request_event_by_id).and_return(event)
-        allow(Batch).to receive(:get_batch_by_id).and_return(target_batch)
+      post "/api/v1/tickets/#{ticket.token}/used"
 
+      expect(response.status).to eq 200
+      expect(response.content_type).to include 'application/json'
+      json_response = JSON.parse(response.body)
+      expect(json_response["usage_status"]).to eq 'used'
+    end
+
+    it 'e não pode ser usado mais de duas vezes por dia' do
+      batches = [
+        {
+        id: '1',
+        name: 'Entrada - Meia',
+        limit_tickets: 20,
+        start_date: 5.days.ago.to_date,
+        value: 20.00,
+        end_date: 2.month.from_now.to_date,
+        event_id: '1'
+        },
+        {
+        id: '2',
+        name: 'PCD - Meia',
+        limit_tickets: 50,
+        start_date: 6.days.ago.to_date,
+        value: 10.00,
+        end_date: 2.month.from_now.to_date,
+        event_id: '1'
+        }
+      ]
+      target_batch = batches[1]
+      event = build(:event, name: 'DevWeek',  event_id: '1', batches: batches,
+                            start_date: Date.today, end_date: 3.days.from_now)
+      ticket = create(:ticket, event_id: '1', batch_id: target_batch[:id])
+      allow(Event).to receive(:request_event_by_id).and_return(event).exactly(2)
+      allow(Batch).to receive(:get_batch_by_id).and_return(target_batch).exactly(2)
+
+      post "/api/v1/tickets/#{ticket.token}/used"
+      post "/api/v1/tickets/#{ticket.token}/used"
+
+      expect(response.status).to eq 422
+      expect(response.content_type).to include 'application/json'
+      json_response = JSON.parse(response.body)
+      expect(json_response["error"]).to eq 'This ticket is already used for this day'
+    end
+
+    it 'e pode ser usado em dias diferente de um evento' do
+      batches = [
+        {
+        id: '1',
+        name: 'Entrada - Meia',
+        limit_tickets: 20,
+        start_date: 5.days.ago.to_date,
+        value: 20.00,
+        end_date: 2.month.from_now.to_date,
+        event_id: '1'
+        },
+        {
+        id: '2',
+        name: 'PCD - Meia',
+        limit_tickets: 50,
+        start_date: 6.days.ago.to_date,
+        value: 10.00,
+        end_date: 2.month.from_now.to_date,
+        event_id: '1'
+        }
+      ]
+      target_batch = batches[1]
+      event = build(:event, name: 'DevWeek',  event_id: '1', batches: batches,
+                            start_date: Date.today, end_date: 3.days.from_now)
+      ticket = create(:ticket, event_id: '1', batch_id: target_batch[:id])
+      allow(Event).to receive(:request_event_by_id).and_return(event).exactly(2)
+      allow(Batch).to receive(:get_batch_by_id).and_return(target_batch).exactly(2)
+
+      post "/api/v1/tickets/#{ticket.token}/used"
+      travel_to 1.day.from_now do
         post "/api/v1/tickets/#{ticket.token}/used"
 
         expect(response.status).to eq 200
         expect(response.content_type).to include 'application/json'
         json_response = JSON.parse(response.body)
         expect(json_response["usage_status"]).to eq 'used'
-      end
-
-      it 'e não pode ser usado mais de duas vezes por dia' do
-        batches = [
-          {
-          id: '1',
-          name: 'Entrada - Meia',
-          limit_tickets: 20,
-          start_date: 5.days.ago.to_date,
-          value: 20.00,
-          end_date: 2.month.from_now.to_date,
-          event_id: '1'
-          },
-          {
-          id: '2',
-          name: 'PCD - Meia',
-          limit_tickets: 50,
-          start_date: 6.days.ago.to_date,
-          value: 10.00,
-          end_date: 2.month.from_now.to_date,
-          event_id: '1'
-          }
-        ]
-        target_batch = batches[1]
-        event = build(:event, name: 'DevWeek',  event_id: '1', batches: batches,
-                              start_date: Date.today, end_date: 3.days.from_now)
-        ticket = create(:ticket, event_id: '1', batch_id: target_batch[:id])
-        allow(Event).to receive(:request_event_by_id).and_return(event).exactly(2)
-        allow(Batch).to receive(:get_batch_by_id).and_return(target_batch).exactly(2)
-
-        post "/api/v1/tickets/#{ticket.token}/used"
-        post "/api/v1/tickets/#{ticket.token}/used"
-
-        expect(response.status).to eq 422
-        expect(response.content_type).to include 'application/json'
-        json_response = JSON.parse(response.body)
-        expect(json_response["error"]).to eq 'This ticket is already used for this day'
-      end
-
-      it 'e pode ser usado em dias diferente de um evento' do
-        batches = [
-          {
-          id: '1',
-          name: 'Entrada - Meia',
-          limit_tickets: 20,
-          start_date: 5.days.ago.to_date,
-          value: 20.00,
-          end_date: 2.month.from_now.to_date,
-          event_id: '1'
-          },
-          {
-          id: '2',
-          name: 'PCD - Meia',
-          limit_tickets: 50,
-          start_date: 6.days.ago.to_date,
-          value: 10.00,
-          end_date: 2.month.from_now.to_date,
-          event_id: '1'
-          }
-        ]
-        target_batch = batches[1]
-        event = build(:event, name: 'DevWeek',  event_id: '1', batches: batches,
-                              start_date: Date.today, end_date: 3.days.from_now)
-        ticket = create(:ticket, event_id: '1', batch_id: target_batch[:id])
-        allow(Event).to receive(:request_event_by_id).and_return(event).exactly(2)
-        allow(Batch).to receive(:get_batch_by_id).and_return(target_batch).exactly(2)
-
-        post "/api/v1/tickets/#{ticket.token}/used"
-        travel_to 1.day.from_now do
-          post "/api/v1/tickets/#{ticket.token}/used"
-
-          expect(response.status).to eq 200
-          expect(response.content_type).to include 'application/json'
-          json_response = JSON.parse(response.body)
-          expect(json_response["usage_status"]).to eq 'used'
-        end
       end
     end
   end

--- a/spec/requests/apis/tickets/tickets_api_spec.rb
+++ b/spec/requests/apis/tickets/tickets_api_spec.rb
@@ -131,18 +131,10 @@ describe 'Tickets API' do
       expect(response.status).to eq 500
     end
   end
+
   context 'E retorna usado ao receber o token do ticket' do
     it 'com sucesso' do
       batches = [
-        {
-        id: '1',
-        name: 'Entrada - Meia',
-        limit_tickets: 20,
-        start_date: 5.days.ago.to_date,
-        value: 20.00,
-        end_date: 2.month.from_now.to_date,
-        event_id: '1'
-        },
         {
         id: '2',
         name: 'PCD - Meia',
@@ -153,7 +145,7 @@ describe 'Tickets API' do
         event_id: '1'
         }
       ]
-      target_batch = batches[1]
+      target_batch = batches[0]
       event = build(:event, name: 'DevWeek',  event_id: '1', batches: batches,
                             start_date: Date.today, end_date: 3.days.from_now)
       ticket = create(:ticket, event_id: '1', batch_id: target_batch[:id])
@@ -171,15 +163,6 @@ describe 'Tickets API' do
     it 'e não pode ser usado mais de duas vezes por dia' do
       batches = [
         {
-        id: '1',
-        name: 'Entrada - Meia',
-        limit_tickets: 20,
-        start_date: 5.days.ago.to_date,
-        value: 20.00,
-        end_date: 2.month.from_now.to_date,
-        event_id: '1'
-        },
-        {
         id: '2',
         name: 'PCD - Meia',
         limit_tickets: 50,
@@ -189,7 +172,7 @@ describe 'Tickets API' do
         event_id: '1'
         }
       ]
-      target_batch = batches[1]
+      target_batch = batches[0]
       event = build(:event, name: 'DevWeek',  event_id: '1', batches: batches,
                             start_date: Date.today, end_date: 3.days.from_now)
       ticket = create(:ticket, event_id: '1', batch_id: target_batch[:id])
@@ -208,15 +191,6 @@ describe 'Tickets API' do
     it 'e pode ser usado em dias diferente de um evento' do
       batches = [
         {
-        id: '1',
-        name: 'Entrada - Meia',
-        limit_tickets: 20,
-        start_date: 5.days.ago.to_date,
-        value: 20.00,
-        end_date: 2.month.from_now.to_date,
-        event_id: '1'
-        },
-        {
         id: '2',
         name: 'PCD - Meia',
         limit_tickets: 50,
@@ -226,7 +200,7 @@ describe 'Tickets API' do
         event_id: '1'
         }
       ]
-      target_batch = batches[1]
+      target_batch = batches[0]
       event = build(:event, name: 'DevWeek',  event_id: '1', batches: batches,
                             start_date: Date.today, end_date: 3.days.from_now)
       ticket = create(:ticket, event_id: '1', batch_id: target_batch[:id])
@@ -242,6 +216,31 @@ describe 'Tickets API' do
         json_response = JSON.parse(response.body)
         expect(json_response["usage_status"]).to eq 'used'
       end
+    end
+
+    it 'e retorna erro do servidor falha com um erro interno' do
+      batches = [
+        {
+        id: '2',
+        name: 'PCD - Meia',
+        limit_tickets: 50,
+        start_date: 6.days.ago.to_date,
+        value: 10.00,
+        end_date: 2.month.from_now.to_date,
+        event_id: '1'
+        }
+      ]
+      target_batch = batches[0]
+      event = build(:event, name: 'DevWeek',  event_id: '1', batches: batches,
+                            start_date: Date.today, end_date: 3.days.from_now)
+      ticket = create(:ticket, event_id: '1', batch_id: target_batch[:id])
+      allow(Event).to receive(:request_event_by_id).and_return(event)
+      allow(Batch).to receive(:get_batch_by_id).and_return(target_batch)
+      allow(Ticket).to receive(:find_by). and_raise(ActiveRecord::ActiveRecordError)
+
+      post "/api/v1/tickets/#{ticket.token}/used"
+
+      expect(response.status).to eq 500
     end
   end
 end


### PR DESCRIPTION
Adicionado um enum de estado de uso ao modelo de ingresso, com os seguintes estados: not_the_date, usable, used.

Criado o modelo de Ingressos Usados para registrar o uso do ingresso, incluindo a data de uso, para garantir que o ingresso não possa ser utilizado mais de uma vez.

Adicionados testes para verificar o funcionamento correto da lógica de uso e validação dos ingressos.

Sobrescritos os métodos do enum de estado de uso do ingresso para incluir validações, garantindo que a transição entre os estados seja consistente.

Testando endpoint:
![Captura de tela de 2025-02-07 13-35-49](https://github.com/user-attachments/assets/ff40e343-3160-4859-9e16-f816b37b06a0)
Resultado:
![Captura de tela de 2025-02-07 13-38-10](https://github.com/user-attachments/assets/56dcc459-25c6-4db0-80eb-7666e105df53)
Testando possa ser usado somente uma vez:
![Captura de tela de 2025-02-07 13-35-53](https://github.com/user-attachments/assets/ffc5b657-915a-4c70-9cae-c16cc0f2f033)


