### PR TITLE
cria rota pra recuperar um feedback de um evento da agenda a partir do schedule_item

### DIFF
--- a/app/controllers/api/v1/item_feedbacks_controller.rb
+++ b/app/controllers/api/v1/item_feedbacks_controller.rb
@@ -1,0 +1,15 @@
+class Api::V1::ItemFeedbacksController < Api::V1::ApiController
+  def index
+    @item_feedbacks = ItemFeedback.where(schedule_item_id: params[:schedule_item_id])
+    if @item_feedbacks.any?
+      item_feedbacks = @item_feedbacks.map { |item_feedback| { id: item_feedback.id, title: item_feedback.title,
+                                                               comment: item_feedback.comment, mark: item_feedback.mark,
+                                                               user: item_feedback.user.full_name,
+                                                               schedule_item_id: item_feedback.schedule_item_id } }
+
+      render status: :ok, json: { item_feedbacks: item_feedbacks }
+    else
+      render status: :not_found, json: { schedule_item_id: params[:schedule_item_id], error: "Feedback items not found" }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,10 @@ Rails.application.routes.draw do
       resources :item_feedbacks do
         resources :feedback_answers, only: [ :create ]
       end
+
+      resources :schedule_items do
+        resources :item_feedbacks, only: [ :index ]
+      end
       resources :tickets, param: :token do
         post "used", on: :member
       end

--- a/spec/requests/apis/item_feedbacks/item_feedback_api_spec.rb
+++ b/spec/requests/apis/item_feedbacks/item_feedback_api_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+describe 'ITEM Feedback API' do
+  context 'Retorna os feedback de um item de um evento' do
+    it 'com sucesso' do
+      user = create(:user, name: 'David', last_name: 'Martinez')
+      user_two = create(:user, name: 'Gabriel', last_name: 'Tavares')
+      create(:item_feedback, title: 'Título do feedback de item', comment: 'Comentário Padrão de item', mark: 4, event_id: '1', schedule_item_id: '1', public: true, user: user)
+      create(:item_feedback, title: 'Uma porcaria', comment: 'Melhor você ganha', mark: 2, event_id: '1', schedule_item_id: '1', public: true, user: user_two)
+      create(:item_feedback, title: 'Uma porcaria', comment: 'Melhor você ganha', mark: 2, event_id: '1', schedule_item_id: '2', public: true, user: user)
+
+      get "/api/v1/schedule_items/1/item_feedbacks"
+
+      expect(response.status).to eq 200
+      expect(response.content_type).to include 'application/json'
+      json_response = JSON.parse(response.body)
+      expect(json_response["item_feedbacks"][0]["id"]).to eq 1
+      expect(json_response["item_feedbacks"][0]["schedule_item_id"]).to eq '1'
+      expect(json_response["item_feedbacks"][0]["title"]).to eq 'Título do feedback de item'
+      expect(json_response["item_feedbacks"][0]["comment"]).to eq 'Comentário Padrão de item'
+      expect(json_response["item_feedbacks"][0]["mark"]).to eq 4
+      expect(json_response["item_feedbacks"][0]["user"]).to eq 'David Martinez'
+      expect(json_response["item_feedbacks"][1]["id"]).to eq 2
+      expect(json_response["item_feedbacks"][1]["schedule_item_id"]).to eq '1'
+      expect(json_response["item_feedbacks"][1]["title"]).to eq 'Uma porcaria'
+      expect(json_response["item_feedbacks"][1]["comment"]).to eq 'Melhor você ganha'
+      expect(json_response["item_feedbacks"][1]["mark"]).to eq 2
+      expect(json_response["item_feedbacks"][1]["user"]).to eq 'Gabriel Tavares'
+    end
+
+    it 'e retorna 404 se não encontra feedbacks disponíveis' do
+      allow(ItemFeedback).to receive(:where).and_return([])
+
+      get "/api/v1/schedule_items/999/item_feedbacks"
+
+      expect(response.status).to eq 404
+      expect(response.content_type).to include 'application/json'
+      json_response = JSON.parse(response.body)
+      expect(json_response["error"]).to eq 'Feedback items not found'
+    end
+
+    it 'E falha com um erro interno' do
+      allow(ItemFeedback).to receive(:where).and_raise(ActiveRecord::QueryCanceled)
+
+      get "/api/v1/schedule_items/1/item_feedbacks"
+
+      expect(response.status).to eq 500
+    end
+  end
+end


### PR DESCRIPTION
1. Declara rota **/api/v1/schedule_items/:schedule_item_code/item_feedbacks**;
2. Cria controller e action para tratamento das requisições;
3. Testes para casos de sucesso e falha;
![Captura de tela de 2025-02-07 22-27-21](https://github.com/user-attachments/assets/00bf5424-02f3-4d67-8d15-f4820c3f11f5)

Resolve #184 