### PR TITLE
Adicionada restrições a feedback anonimos 

### DIFF
--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -1,7 +1,8 @@
 class FeedbacksController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_and_check_my_event_id
+  before_action :set_and_check_my_event_id  
   before_action -> { check_user_is_participant(@my_event_id) }
+  before_action :set_and_check_feedback, only: :show
 
   def new
     @feedback = Feedback.new
@@ -25,9 +26,7 @@ class FeedbacksController < ApplicationController
     @item_feedbacks = ItemFeedback.where(user: current_user, event_id: @my_event_id)
   end
 
-  def show
-    @feedback = Feedback.find(params[:id])
-  end
+  def show;  end
 
   private
 
@@ -39,5 +38,10 @@ class FeedbacksController < ApplicationController
     @my_event_id = params[:my_event_id]
     @event = Event.request_event_by_id(@my_event_id)
     redirect_to root_path, alert: t(".no_finished") if @event.end_date > DateTime.now
+  end
+
+  def set_and_check_feedback
+    @feedback = Feedback.find(params[:id])
+    redirect_to root_path, alert: t(".not_yours") unless @feedback.public && current_user == @feedback.user
   end
 end

--- a/app/controllers/item_feedbacks_controller.rb
+++ b/app/controllers/item_feedbacks_controller.rb
@@ -3,6 +3,7 @@ class ItemFeedbacksController < ApplicationController
   before_action :set_and_check_my_event
   before_action :set_and_check_schedule
   before_action -> { check_user_is_participant(@my_event_id) }
+  before_action :set_and_check_item_feedback, only: :show
 
   def new
     @item_feedback = ItemFeedback.new()
@@ -23,7 +24,6 @@ class ItemFeedbacksController < ApplicationController
   end
 
   def show
-    @item_feedback = ItemFeedback.find(params[:id])
     @feedback_answer = FeedbackAnswer.find_by(item_feedback: @item_feedback.id)
   end
 
@@ -43,5 +43,10 @@ class ItemFeedbacksController < ApplicationController
     @schedule_item_id = params[:schedule_item_id]
     @schedule_item = @event.schedules.flat_map(&:schedule_items).find { |item_schedule| item_schedule.schedule_item_id == @schedule_item_id }
     redirect_to root_path, alert: t(".no_schedule") unless @schedule_item
+  end
+
+  def set_and_check_item_feedback
+    @item_feedback = ItemFeedback.find(params[:id])
+    redirect_to root_path, alert: t(".not_yours") unless @item_feedback.public && current_user == @item_feedback.user
   end
 end

--- a/app/controllers/my_events_controller.rb
+++ b/app/controllers/my_events_controller.rb
@@ -12,8 +12,8 @@ class MyEventsController < ApplicationController
     @batches = @tickets_by_batch_id.keys.each_with_object(Hash.new) { |batch_id, hash| hash[batch_id] = Batch.request_batch_by_id(params[:id], batch_id) }
     @event = Event.request_event_by_id(params[:id])
     @posts = Post.where(event_id: params[:id])
-    @feedbacks = Feedback.where(event_id: params[:id])
-    @item_feedbacks = ItemFeedback.where(event_id: params[:id])
+    @feedbacks = Feedback.where(event_id: params[:id], public: true)
+    @item_feedbacks = ItemFeedback.where(event_id: params[:id], public: true)
     @announcements = Announcement.request_announcements_by_event_id(@event.event_id)
   end
 end

--- a/app/views/my_events/index.html.erb
+++ b/app/views/my_events/index.html.erb
@@ -9,7 +9,7 @@
       <div id="event_id_<%=event.event_id%>"  class="bg-white shadow-lg rounded-lg overflow-hidden hover:shadow-xl transition">
           <%= render '/events/event', event: event %>
           <%= link_to t('.event_details'), my_event_path(id: event.event_id), class: 'mt-4 w-full bg-blue-600 text-white py-2 rounded-lg hover:bg-blue-700 transition block p-6 text-center' %>
-          <% if event.end_date < Date.today %>
+          <% if event.end_date < DateTime.now %>
               <%= link_to t('.add_feedback'), new_my_event_feedback_path(event.event_id), class: 'mt-4 w-full bg-blue-600 text-white py-2 rounded-lg hover:bg-blue-700 transition block p-6 text-center' %>
               <%= link_to t('.see_feedbacks'), my_event_feedbacks_path(event.event_id), class: 'mt-4 w-full bg-blue-600 text-white py-2 rounded-lg hover:bg-blue-700 transition block p-6 text-center' %>              
           <% end %>

--- a/app/views/my_events/index.html.erb
+++ b/app/views/my_events/index.html.erb
@@ -9,7 +9,7 @@
       <div id="event_id_<%=event.event_id%>"  class="bg-white shadow-lg rounded-lg overflow-hidden hover:shadow-xl transition">
           <%= render '/events/event', event: event %>
           <%= link_to t('.event_details'), my_event_path(id: event.event_id), class: 'mt-4 w-full bg-blue-600 text-white py-2 rounded-lg hover:bg-blue-700 transition block p-6 text-center' %>
-          <% if event.end_date < DateTime.now %>
+          <% if event.end_date < Date.today %>
               <%= link_to t('.add_feedback'), new_my_event_feedback_path(event.event_id), class: 'mt-4 w-full bg-blue-600 text-white py-2 rounded-lg hover:bg-blue-700 transition block p-6 text-center' %>
               <%= link_to t('.see_feedbacks'), my_event_feedbacks_path(event.event_id), class: 'mt-4 w-full bg-blue-600 text-white py-2 rounded-lg hover:bg-blue-700 transition block p-6 text-center' %>              
           <% end %>

--- a/config/locales/views/feedbacks/en.yml
+++ b/config/locales/views/feedbacks/en.yml
@@ -11,3 +11,5 @@ en:
     create: 
       success: Feedback successfully added
       alert: Failed to save Feedback
+    show:
+      not_yours: You don't have access to this feedback

--- a/config/locales/views/feedbacks/pt-BR.yml
+++ b/config/locales/views/feedbacks/pt-BR.yml
@@ -11,3 +11,5 @@ pt-BR:
     create: 
       success: Feedback adicionado com sucesso
       alert: Falha ao salvar o Feedback
+    show: 
+    not_yours: Você não possui acesso a esse feedback

--- a/config/locales/views/item_feedbacks/en.yml
+++ b/config/locales/views/item_feedbacks/en.yml
@@ -7,3 +7,5 @@ en:
     create:       
       success: Feedback added with success
       alert: Failed to save feedback
+    show:
+      not_yours: You don't have access to this feedback

--- a/config/locales/views/item_feedbacks/pt-BR.yml
+++ b/config/locales/views/item_feedbacks/pt-BR.yml
@@ -7,3 +7,5 @@ pt-BR:
     create:       
       success: Feedback adicionado com sucesso
       alert: Falha ao salvar o Feedback
+    show: 
+    not_yours: Você não possui acesso a esse feedback

--- a/spec/system/item_feedbacks/user_see_item_feedback_spec.rb
+++ b/spec/system/item_feedbacks/user_see_item_feedback_spec.rb
@@ -150,4 +150,46 @@ describe 'Usuário feedback de um  item de um evento' do
       expect(page).to have_content 'email@teste.com'
     end
   end
+
+  it 'e não pode ver feedback anonimo de outro usuario' do
+    user = create(:user)
+    schedules = [
+      {
+        date: 	5.day.ago,
+        schedule_items: [
+          {
+            name:	"Palestra",
+            start_time:	5.day.ago.beginning_of_day + 9.hours,
+            end_time:	5.day.ago.beginning_of_day + 10.hours,
+            code: '1'
+          }
+        ]
+      }
+    ]
+    batches = [ {
+        batch_id: '1',
+        name: 'Entrada - Meia',
+        limit_tickets: 20,
+        start_date: 5.days.ago.to_date,
+        value: 20.00,
+        end_date: 2.month.from_now.to_date,
+        event_id: '1'
+      }
+    ]
+    event = build(:event, name: 'DevWeek', batches: batches, event_id: '1', start_date: 5.days.ago, end_date: 1.day.ago, schedules: schedules)
+    ticket = create(:ticket, event_id: event.event_id, batch_id: '1')
+    create(:ticket, event_id: event.event_id, batch_id: '1', user: user)
+    schedule_item = event.schedules[0].schedule_items[0]
+    batches.map! { |batch| build(:batch, **batch) }
+    allow(Batch).to receive(:request_batch_by_id).with("1", '1').and_return(batches[0])
+    allow(Event).to receive(:request_event_by_id).and_return(event)
+    item_feedback = create(:item_feedback, title: 'Título Padrão', comment: 'Comentário Padrão', mark: 3, event_id: event.event_id,
+                            user: ticket.user, public: false, schedule_item_id: schedule_item.schedule_item_id)
+
+    login_as ticket.user
+
+    visit my_event_schedule_item_item_feedback_path(my_event_id: item_feedback.event_id, schedule_item_id: item_feedback.schedule_item.schedule_item_id, id: item_feedback.id)
+
+    expect(page).to have_content 'Você não possui acesso a esse feedback'
+  end
 end

--- a/spec/system/my_events/user_view_my_events_details_spec.rb
+++ b/spec/system/my_events/user_view_my_events_details_spec.rb
@@ -292,4 +292,84 @@ describe "Participante de um evento acessa mais detalhes do evento", type: :syst
 
     expect(page).to have_content 'Erro do servidor'
   end
+
+  it 'e não vê feedbacks anonimos' do
+    user = create(:user, name: 'David', last_name: 'Martinez')
+    batches = [ {
+        batch_id: '1',
+        name: 'Entrada - Meia',
+        limit_tickets: 20,
+        start_date: 5.days.ago.to_date,
+        value: 20.00,
+        end_date: 2.month.from_now.to_date,
+        event_id: '1'
+      }
+    ]
+    event = build(:event, name: 'DevWeek', batches: batches, event_id: '1', start_date: 5.days.ago, end_date: 1.day.ago)
+    ticket = create(:ticket, event_id: event.event_id, batch_id: '1', user: user)
+    batches.map! { |batch| build(:batch, **batch) }
+    allow(Batch).to receive(:request_batch_by_id).with("1", '1').and_return(batches[0])
+    allow(Event).to receive(:request_event_by_id).and_return(event)
+
+    login_as ticket.user
+    create(:feedback, title: 'Título Padrão', comment: 'Comentário Padrão', mark: 3, event_id: event.event_id,
+                      user: user, public: true)
+    create(:feedback, title: 'Título Padrão 2', comment: 'Comentário Padrão 2', mark: 1, event_id: event.event_id,
+                      user: user, public: false)
+    visit my_event_path(event.event_id, locale: :'pt-BR')
+
+    expect(page).to have_content 'Feedback'
+    expect(page).to have_content 'David Martinez'
+    expect(page).to have_content 'Título Padrão'
+    expect(page).to have_content 'Nota: 3'
+    expect(page).not_to have_content 'Título Padrão 2'
+    expect(page).not_to have_content 'Nota: 1'
+  end
+
+  it 'e não consegue ver feedback de um item de um evento anonimos' do
+    user = create(:user, name: 'David', last_name: 'Martinez')
+    batches = [ {
+        batch_id: '1',
+        name: 'Entrada - Meia',
+        limit_tickets: 20,
+        start_date: 5.days.ago.to_date,
+        value: 20.00,
+        end_date: 2.month.from_now.to_date,
+        event_id: '1'
+      }
+    ]
+    schedules = [
+      {
+        date: 	5.day.ago,
+        schedule_items: [
+          {
+            name:	"Palestra",
+            start_time:	5.day.ago.beginning_of_day + 9.hours,
+            end_time:	5.day.ago.beginning_of_day + 10.hours,
+            code: '1'
+          }
+        ]
+      }
+    ]
+    event = build(:event, name: 'DevWeek', batches: batches, event_id: '1', start_date: 5.days.ago, end_date: 1.day.ago, schedules: schedules)
+    schedule_item = event.schedules[0].schedule_items[0]
+    ticket = create(:ticket, event_id: event.event_id, batch_id: '1', user: user)
+    batches.map! { |batch| build(:batch, **batch) }
+    allow(Batch).to receive(:request_batch_by_id).with("1", '1').and_return(batches[0])
+    allow(Event).to receive(:request_event_by_id).and_return(event)
+
+    login_as ticket.user
+    create(:item_feedback, title: 'Título Padrão', comment: 'Comentário Padrão', mark: 3, event_id: event.event_id,
+                                      user: user, public: true, schedule_item_id: schedule_item.schedule_item_id)
+    create(:item_feedback, title: 'Título Padrão 2', comment: 'Comentário Padrão', mark: 1, event_id: event.event_id,
+                                      user: user, public: false, schedule_item_id: schedule_item.schedule_item_id)
+    visit my_event_path(event.event_id, locale: :'pt-BR')
+
+    expect(page).to have_content 'Feedback'
+    expect(page).to have_content 'David Martinez'
+    expect(page).to have_content 'Título Padrão'
+    expect(page).to have_content 'Nota: 3'
+    expect(page).not_to have_content 'Título Padrão 2'
+    expect(page).not_to have_content 'Nota: 1'
+  end
 end


### PR DESCRIPTION
Adicionada restrições na tela de detalhes de feedbacks e testes, e adiciona condição para mostrar só feedbacks publicos no feed do evento 

Resolve #216 