### PR TITLE
Adicionado user_identification como anonimo se feedback ou item_feedback nao for publico

### DIFF
--- a/app/controllers/api/v1/feedbacks_controller.rb
+++ b/app/controllers/api/v1/feedbacks_controller.rb
@@ -12,7 +12,7 @@ class Api::V1::FeedbacksController < Api::V1::ApiController
 
       feedback_json = @feedbacks.map { |feedback| { id: feedback.id, title: feedback.title,
                                                     comment: feedback.comment, mark: feedback.mark,
-                                                    user: feedback.user.full_name } }
+                                                    user: feedback.user_identification } }
 
       render status: :ok, json: { event_id: @event.event_id, feedbacks: feedback_json, item_feedbacks: item_feedbacks }
     else

--- a/app/controllers/api/v1/item_feedbacks_controller.rb
+++ b/app/controllers/api/v1/item_feedbacks_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::ItemFeedbacksController < Api::V1::ApiController
     if @item_feedbacks.any?
       item_feedbacks = @item_feedbacks.map { |item_feedback| { id: item_feedback.id, title: item_feedback.title,
                                                                comment: item_feedback.comment, mark: item_feedback.mark,
-                                                               user: item_feedback.user.full_name,
+                                                               user: item_feedback.user_identification,
                                                                schedule_item_id: item_feedback.schedule_item_id } }
 
       render status: :ok, json: { item_feedbacks: item_feedbacks }

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -4,4 +4,8 @@ class Feedback < ApplicationRecord
   validates :title, :comment, :mark, presence: true
   validates :comment, length: { maximum: 150 }
   validates :mark, inclusion: { in: [ 1, 2, 3, 4, 5 ] }
+
+  def user_identification
+    self.public ? user.full_name : "Anônimo"
+  end
 end

--- a/app/models/item_feedback.rb
+++ b/app/models/item_feedback.rb
@@ -8,4 +8,8 @@ class ItemFeedback < ApplicationRecord
     event = Event.request_event_by_id(self.event_id)
     event.schedules.flat_map(&:schedule_items).find { |item_schedule| item_schedule.schedule_item_id == self.schedule_item_id }
   end
+
+  def user_identification
+    self.public ? user.full_name : "Anônimo"
+  end
 end

--- a/spec/factories/feedbacks.rb
+++ b/spec/factories/feedbacks.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     title { "Título Padrão" }
     comment { "Comentário Padrão" }
     mark { 1 }
+    public { false }
   end
 end

--- a/spec/factories/item_feedbacks.rb
+++ b/spec/factories/item_feedbacks.rb
@@ -6,5 +6,6 @@ FactoryBot.define do
     comment { "Comentário Padrão" }
     mark { 1 }
     schedule_item_id { "1" }
+    public { false }
   end
 end

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -15,4 +15,19 @@ RSpec.describe Feedback, type: :model do
       it { is_expected.to validate_inclusion_of(:mark).in_range(1..5) }
     end
   end
+
+  context '.user_indentification' do
+    it 'Deve retornar Anônimo se public for falso' do
+      feedback = create(:feedback, public: false)
+
+      expect(feedback.user_identification).to eq "Anônimo"
+    end
+
+    it 'Deve retornar o nome completo do usuario se public for true' do
+      user = create(:user, name: "André", last_name: "Kanamura")
+      feedback = create(:feedback, user: user, public: true)
+
+      expect(feedback.user_identification).to eq "André Kanamura"
+    end
+  end
 end

--- a/spec/models/item_feedback_spec.rb
+++ b/spec/models/item_feedback_spec.rb
@@ -15,4 +15,19 @@ RSpec.describe ItemFeedback, type: :model do
       it { is_expected.to validate_inclusion_of(:mark).in_range(1..5) }
     end
   end
+
+  context '.user_indentification' do
+    it 'Deve retornar Anônimo se public for falso' do
+      item_feedback = create(:item_feedback, public: false)
+
+      expect(item_feedback.user_identification).to eq "Anônimo"
+    end
+
+    it 'Deve retornar o nome completo do usuario se public for true' do
+      user = create(:user, name: "André", last_name: "Kanamura")
+      item_feedback = create(:item_feedback, user: user, public: true)
+
+      expect(item_feedback.user_identification).to eq "André Kanamura"
+    end
+  end
 end

--- a/spec/requests/apis/feedbacks/feedbacks_api_spec.rb
+++ b/spec/requests/apis/feedbacks/feedbacks_api_spec.rb
@@ -49,7 +49,7 @@ describe 'Feedback API' do
         expect(json_response["feedbacks"][0]["title"]).to eq 'Título'
         expect(json_response["feedbacks"][0]["comment"]).to eq 'Comentário'
         expect(json_response["feedbacks"][0]["mark"]).to eq 4
-        expect(json_response["feedbacks"][0]["user"]).to eq 'Gabriel Tavares'
+        expect(json_response["feedbacks"][0]["user"]).to eq 'Anônimo'
         expect(json_response["feedbacks"][1]["id"]).to eq 2
         expect(json_response["feedbacks"][1]["title"]).to eq 'Título Padrão'
         expect(json_response["feedbacks"][1]["comment"]).to eq 'Comentário Padrão'
@@ -74,7 +74,7 @@ describe 'Feedback API' do
       travel_to 6.days.from_now do
         login_as user
         create(:feedback, title: 'Título', comment: 'Comentário', mark: 4, event_id: event.event_id,
-               user: user, public: false)
+               user: user, public: true)
         login_as other_user
         create(:feedback, title: 'Título Padrão', comment: 'Comentário Padrão', mark: 3, event_id: event.event_id,
                user: other_user, public: true)


### PR DESCRIPTION
Verifica o tipo do feedback para determinar a identificação do usuário. 